### PR TITLE
scale, then round in set_native_value

### DIFF
--- a/custom_components/eta_webservices/number.py
+++ b/custom_components/eta_webservices/number.py
@@ -104,8 +104,7 @@ class EtaWritableNumberSensor(NumberEntity, EtaWritableSensorEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
-        raw_value = round(value, self.valid_values["dec_places"])
-        raw_value *= self.valid_values["scale_factor"]
+        raw_value = round(value * self.valid_values["scale_factor"], self.valid_values["dec_places"])
         eta_client = EtaAPI(self.session, self.host, self.port)
         success = await eta_client.write_endpoint(self.uri, raw_value)
         if not success:


### PR DESCRIPTION
Sending decimal values wasn't possible prior to this change.

This call results to 21.0 being set:
```
action: number.set_value
data:
  value: "22.1"
target:
  entity_id: >-
    number.eta_<name>_garderobe_eingange_raumtemperatur_uber_externe_schnittstellen_writable

```

In the diagnsotic data, the endpoint is defined as:
```
        "eta_<name>__garderobe_eing\u00e4nge_raumtemperatur_\u00fcber_externe_schnittstellen": {
          "endpoint_type": "TEXT",
          "friendly_name": "Garderobe > Eing\u00e4nge > Raumtemperatur \u00fcber externe Schnittstellen",
          "unit": "\u00b0C",
          "url": "/120/10441/0/0/13046",
          "valid_values": {
            "dec_places": 0,
            "scale_factor": 10,
            "scaled_max_value": 200,
            "scaled_min_value": -100
          },
          "value": 20.0
        },
```

Using the manual service call works fine though:
```
action: eta_webservices.write_value
data: {
  endpoint_url: /120/10441/0/0/13046,
  value: 221
}
```

Not sure if this is a problem in the valid value definition supplied by eta or in the translation to fixed, but probably https://github.com/Tidone/homeassistant_eta_integration/blob/e90eba2b6bdde8ccc67cff35e2cd0dcac0a0ecb9/custom_components/eta_webservices/number.py#L107 should apply scaling first and then round?  

I didn't find any decPlaces != 0, and the ETA API spec is not very clear in this point.