### PR TITLE
Fix exception when adding sensors with custom units

### DIFF
--- a/custom_components/eta_webservices/__init__.py
+++ b/custom_components/eta_webservices/__init__.py
@@ -1,15 +1,26 @@
+"""The ETA Sensors integration."""
+
 import logging
+from typing import Any
+
 from homeassistant import config_entries, core
 from homeassistant.const import Platform
 
-from .const import DOMAIN, ERROR_UPDATE_COORDINATOR, WRITABLE_UPDATE_COORDINATOR
+from .const import (
+    CHOSEN_FLOAT_SENSORS,
+    CHOSEN_TEXT_SENSORS,
+    CHOSEN_WRITABLE_SENSORS,
+    CUSTOM_UNIT_MINUTES_SINCE_MIDNIGHT,
+    DOMAIN,
+    ERROR_UPDATE_COORDINATOR,
+    FLOAT_DICT,
+    FORCE_LEGACY_MODE,
+    TEXT_DICT,
+    WRITABLE_DICT,
+    WRITABLE_UPDATE_COORDINATOR,
+)
 from .coordinator import ETAErrorUpdateCoordinator, ETAWritableUpdateCoordinator
 from .services import async_setup_services
-from .const import (
-    WRITABLE_DICT,
-    CHOSEN_WRITABLE_SENSORS,
-    FORCE_LEGACY_MODE,
-)
 
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
@@ -34,6 +45,8 @@ async def async_setup_entry(
     # Store a reference to the unsubscribe function to cleanup if an entry is unloaded.
     config["unsub_options_update_listener"] = unsub_options_update_listener
 
+    # Merge the options with the config
+    # The options are set if a user configures the integration after the initial set-up
     if entry.options:
         config.update(entry.options)
 
@@ -58,7 +71,47 @@ async def async_setup_entry(
 async def async_migrate_entry(
     hass: core.HomeAssistant, config_entry: config_entries.ConfigEntry
 ):
+    # Move all sensors with the custom CUSTOM_UNIT_MINUTES_SINCE_MIDNIGHT unit
+    # from the list of float sensors to the list of text sensors
+    # also make sure to move currently selected sensors
+    def migrate_to_v6(new_data: dict[str, Any]):
+        # Merge the options with the initial data to make sure we operate on the most recent data
+        if config_entry.options:
+            new_data.update(config_entry.options)
+
+        chosen_custom_unit_sensors = [
+            entry
+            for entry in new_data[CHOSEN_FLOAT_SENSORS]
+            if new_data[FLOAT_DICT][entry]["unit"] == CUSTOM_UNIT_MINUTES_SINCE_MIDNIGHT
+        ]
+        # remove sensors with custom units from the CHOSEN_FLOAT_SENSORS list
+        new_data[CHOSEN_FLOAT_SENSORS] = [
+            entry
+            for entry in new_data[CHOSEN_FLOAT_SENSORS]
+            if entry not in chosen_custom_unit_sensors
+        ]
+        # and add them to the CHOSEN_TEXT_SENSORS list instead
+        new_data[CHOSEN_TEXT_SENSORS].extend(chosen_custom_unit_sensors)
+
+        # now do the same with the FLOAT_DICT dict
+        custom_unit_sensors = {
+            k: v
+            for k, v in new_data[FLOAT_DICT].items()
+            if v.get("unit", "") == CUSTOM_UNIT_MINUTES_SINCE_MIDNIGHT
+        }
+        # remove sensors with custom units from the FLOAT_DICT
+        new_data[FLOAT_DICT] = {
+            k: v
+            for k, v in new_data[FLOAT_DICT].items()
+            if k not in custom_unit_sensors
+        }
+        # and add them to the TEXT_DICT instead
+        new_data[TEXT_DICT].update(custom_unit_sensors)
+
     _LOGGER.debug("Migrating from version %s", config_entry.version)
+
+    new_version = 6
+
     if config_entry.version == 1:
         new_data = config_entry.data.copy()
 
@@ -66,18 +119,41 @@ async def async_migrate_entry(
         new_data[CHOSEN_WRITABLE_SENSORS] = []
         new_data[FORCE_LEGACY_MODE] = False
 
-        hass.config_entries.async_update_entry(config_entry, data=new_data, version=5)
+        migrate_to_v6(new_data)
+
+        hass.config_entries.async_update_entry(
+            config_entry,
+            data=new_data,
+            options={},
+            version=new_version,
+        )
     elif config_entry.version == 2:
         new_data = config_entry.data.copy()
 
         new_data[FORCE_LEGACY_MODE] = False
 
-        hass.config_entries.async_update_entry(config_entry, data=new_data, version=5)
-    elif config_entry.version in (3, 4):
-        new_data = config_entry.data.copy()
-        hass.config_entries.async_update_entry(config_entry, data=new_data, version=5)
+        migrate_to_v6(new_data)
 
-    _LOGGER.info("Migration to version %s successful", config_entry.version)
+        hass.config_entries.async_update_entry(
+            config_entry,
+            data=new_data,
+            options={},
+            version=new_version,
+        )
+    elif config_entry.version in (3, 4, 5):
+        new_data = config_entry.data.copy()
+        migrate_to_v6(new_data)
+        hass.config_entries.async_update_entry(
+            config_entry,
+            data=new_data,
+            options={},
+            version=new_version,
+        )
+    else:
+        _LOGGER.warning("No migration path to version %s found", new_version)
+        return True
+
+    _LOGGER.info("Migration to version %s successful", new_version)
     return True
 
 

--- a/custom_components/eta_webservices/api.py
+++ b/custom_components/eta_webservices/api.py
@@ -1,3 +1,5 @@
+"""Handle all low-level API calls for ETA Sensors."""
+
 from datetime import datetime
 import logging
 from typing import TypedDict
@@ -7,6 +9,7 @@ from packaging import version
 import xmltodict
 
 from .const import CUSTOM_UNIT_MINUTES_SINCE_MIDNIGHT
+
 # Make sure to update _get_all_sensors_v12() if a new custom unit is added
 
 _LOGGER = logging.getLogger(__name__)
@@ -70,7 +73,6 @@ class EtaAPI:
             "s",
             "°C",
             "%rH",
-            CUSTOM_UNIT_MINUTES_SINCE_MIDNIGHT,
         ]
 
         self._writable_sensor_units = [
@@ -390,7 +392,9 @@ class EtaAPI:
         )
 
     def _is_text_sensor(self, endpoint_info: ETAEndpoint):
-        return endpoint_info["unit"] == "" and endpoint_info["endpoint_type"] == "TEXT"
+        return endpoint_info["unit"] == CUSTOM_UNIT_MINUTES_SINCE_MIDNIGHT or (
+            endpoint_info["unit"] == "" and endpoint_info["endpoint_type"] == "TEXT"
+        )
 
     def _is_float_sensor(self, endpoint_info: ETAEndpoint):
         return endpoint_info["unit"] in self._float_sensor_units

--- a/custom_components/eta_webservices/manifest.json
+++ b/custom_components/eta_webservices/manifest.json
@@ -5,8 +5,9 @@
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/Tidone/homeassistant_eta_integration",
+  "integration_type": "device",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/Tidone/homeassistant_eta_integration/issues",
   "requirements": ["xmltodict", "packaging"],
-  "version": "1.1.14"
+  "version": "1.1.15"
 }

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for eta_webservices integration."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+"""Pytest configuration and shared fixtures."""
+
+import json
+from pathlib import Path
+import pytest
+
+
+@pytest.fixture
+def fixture_data_dir():
+    """Return path to fixture data directory."""
+    return Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture
+def load_fixture(fixture_data_dir):
+    """Load fixture data from JSON files."""
+    def _load(filename: str) -> dict:
+        """Load and parse JSON fixture file."""
+        fixture_path = fixture_data_dir / filename
+        with open(fixture_path, "r") as f:
+            return json.load(f)
+    return _load

--- a/tests/custom_components/__init__.py
+++ b/tests/custom_components/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for custom components."""

--- a/tests/custom_components/eta_webservices/__init__.py
+++ b/tests/custom_components/eta_webservices/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for eta_webservices integration."""

--- a/tests/custom_components/eta_webservices/test_init.py
+++ b/tests/custom_components/eta_webservices/test_init.py
@@ -1,0 +1,178 @@
+"""Tests for eta_webservices/__init__.py migrations."""
+
+import pytest
+from unittest.mock import Mock, MagicMock
+from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntry
+from copy import deepcopy
+
+from custom_components.eta_webservices import async_migrate_entry
+from custom_components.eta_webservices.const import (
+    CHOSEN_FLOAT_SENSORS,
+    CHOSEN_TEXT_SENSORS,
+    CHOSEN_WRITABLE_SENSORS,
+    CUSTOM_UNIT_MINUTES_SINCE_MIDNIGHT,
+    DOMAIN,
+    FLOAT_DICT,
+    FORCE_LEGACY_MODE,
+    TEXT_DICT,
+    WRITABLE_DICT,
+    SWITCHES_DICT,
+)
+
+
+@pytest.mark.asyncio
+async def test_async_migrate_entry_v5_to_v6(load_fixture):
+    """Test migration from version 5 to 6 with real fixture data.
+    
+    This test verifies:
+    - Entries in FLOAT_DICT without custom unit stay in FLOAT_DICT
+    - Entries in FLOAT_DICT with custom unit move to TEXT_DICT
+    - Chosen entries in CHOSEN_FLOAT_SENSORS with custom unit move to CHOSEN_TEXT_SENSORS
+    - All other dicts and lists remain unchanged
+    """
+    # Setup
+    hass = MagicMock(spec=HomeAssistant)
+    hass.config_entries = MagicMock()
+    
+    # Create config entry for version 5
+    config_entry = MagicMock(spec=ConfigEntry)
+    config_entry.version = 5
+    
+    # Load real fixture data from extracted ETA config
+    fixture_file = load_fixture("v5_config_data.json")
+    original_data = deepcopy(fixture_file["data"])
+    original_options = deepcopy(fixture_file.get("options", {}))
+    
+    # Map fixture keys to const keys in data
+    original_data[FLOAT_DICT] = original_data.pop("FLOAT_DICT")
+    original_data[TEXT_DICT] = original_data.pop("TEXT_DICT", {})
+    original_data[SWITCHES_DICT] = original_data.pop("SWITCHES_DICT", {})
+    original_data[CHOSEN_FLOAT_SENSORS] = original_data.pop("chosen_float_sensors")
+    original_data[CHOSEN_TEXT_SENSORS] = original_data.pop("chosen_text_sensors")
+    original_data[CHOSEN_WRITABLE_SENSORS] = original_data.pop("chosen_writable_sensors")
+    original_data[WRITABLE_DICT] = original_data.pop("WRITABLE_DICT", {})
+    original_data[FORCE_LEGACY_MODE] = original_data.pop("force_legacy_mode")
+
+    # Map fixture keys to const keys in data
+    original_options[FLOAT_DICT] = original_options.pop("FLOAT_DICT")
+    original_options[TEXT_DICT] = original_options.pop("TEXT_DICT", {})
+    original_options[SWITCHES_DICT] = original_options.pop("SWITCHES_DICT", {})
+    original_options[CHOSEN_FLOAT_SENSORS] = original_options.pop("chosen_float_sensors")
+    original_options[CHOSEN_TEXT_SENSORS] = original_options.pop("chosen_text_sensors")
+    original_options[CHOSEN_WRITABLE_SENSORS] = original_options.pop("chosen_writable_sensors")
+    original_options[WRITABLE_DICT] = original_options.pop("WRITABLE_DICT", {})
+    original_options[FORCE_LEGACY_MODE] = original_options.pop("force_legacy_mode")
+    
+    # Use deepcopy to ensure original_data is not modified by config_entry.data
+    config_entry.data = deepcopy(original_data)
+    config_entry.options = deepcopy(original_options)
+    
+    # Mock async_update_entry
+    hass.config_entries.async_update_entry = Mock()
+    
+    # Execute migration
+    result = await async_migrate_entry(hass, config_entry)
+    
+    # Assertions
+    assert result is True
+
+    # Merge original options into original data for comparison
+    original_data.update(original_options)
+    
+    # Get the data that was passed to async_update_entry
+    hass.config_entries.async_update_entry.assert_called_once()
+    call_kwargs = hass.config_entries.async_update_entry.call_args.kwargs
+    new_data = call_kwargs["data"]
+    new_options = call_kwargs.get("options", {})
+    
+    # Verify version was updated
+    assert call_kwargs["version"] == 6
+    
+    # ===== FLOAT_DICT Assertions =====
+    # Count entries with custom unit in original FLOAT_DICT
+    original_float_count = len(original_data[FLOAT_DICT])
+    custom_unit_entries = [
+        k for k, v in original_data[FLOAT_DICT].items()
+        if v.get("unit") == CUSTOM_UNIT_MINUTES_SINCE_MIDNIGHT
+    ]
+    expected_float_count = original_float_count - len(custom_unit_entries)
+    
+    # Entries with standard units should remain in FLOAT_DICT
+    assert len(new_data[FLOAT_DICT]) == expected_float_count, \
+        f"Expected {expected_float_count} entries in FLOAT_DICT, got {len(new_data[FLOAT_DICT])}"
+    
+    # None of the entries in FLOAT_DICT should have custom unit
+    for entry_key, entry_data in new_data[FLOAT_DICT].items():
+        assert entry_data.get("unit") != CUSTOM_UNIT_MINUTES_SINCE_MIDNIGHT, \
+            f"Entry {entry_key} with custom unit should not be in FLOAT_DICT"
+    
+    # Verify that all non-custom-unit entries from original FLOAT_DICT are still present
+    for orig_key, orig_data in original_data[FLOAT_DICT].items():
+        if orig_data.get("unit") != CUSTOM_UNIT_MINUTES_SINCE_MIDNIGHT:
+            assert orig_key in new_data[FLOAT_DICT], \
+                f"Non-custom-unit entry {orig_key} should still be in FLOAT_DICT"
+    
+    # ===== TEXT_DICT Assertions =====
+    # All original text entries should still exist
+    for orig_key in original_data[TEXT_DICT]:
+        assert orig_key in new_data[TEXT_DICT], \
+            f"Original text entry {orig_key} should still be in TEXT_DICT"
+    
+    # All custom unit entries from FLOAT_DICT should now be in TEXT_DICT
+    for custom_unit_key in custom_unit_entries:
+        assert custom_unit_key in new_data[TEXT_DICT], \
+            f"Entry {custom_unit_key} with custom unit should be in TEXT_DICT"
+        assert new_data[TEXT_DICT][custom_unit_key]["unit"] == CUSTOM_UNIT_MINUTES_SINCE_MIDNIGHT, \
+            f"Entry {custom_unit_key} should have custom unit in TEXT_DICT"
+    
+    # TEXT_DICT should have grown by the number of entries migrated
+    original_text_count = len(original_data[TEXT_DICT])
+    new_text_count = len(new_data[TEXT_DICT])
+    migrated_count = new_text_count - original_text_count
+    assert migrated_count == len(custom_unit_entries), \
+        f"TEXT_DICT should have {len(custom_unit_entries)} more entries after migration, but has {migrated_count} more"
+    
+    # ===== CHOSEN_FLOAT_SENSORS Assertions =====
+    # Entries without custom unit should remain
+    original_chosen_float = original_data[CHOSEN_FLOAT_SENSORS].copy()
+    expected_chosen_float = [k for k in original_chosen_float if k not in custom_unit_entries]
+    
+    assert set(new_data[CHOSEN_FLOAT_SENSORS]) == set(expected_chosen_float), \
+        f"CHOSEN_FLOAT_SENSORS mismatch. Expected {set(expected_chosen_float)}, got {set(new_data[CHOSEN_FLOAT_SENSORS])}"
+    
+    # Entry with custom unit should be removed from CHOSEN_FLOAT_SENSORS
+    for custom_unit_key in custom_unit_entries:
+        assert custom_unit_key not in new_data[CHOSEN_FLOAT_SENSORS], \
+            f"Custom unit entry {custom_unit_key} should be removed from CHOSEN_FLOAT_SENSORS"
+    
+    # ===== CHOSEN_TEXT_SENSORS Assertions =====
+    # Original entries should still be there
+    original_chosen_text = original_data[CHOSEN_TEXT_SENSORS].copy()
+    # Add custom unit entries that were in CHOSEN_FLOAT_SENSORS
+    custom_unit_in_chosen = [k for k in custom_unit_entries if k in original_chosen_float]
+    expected_chosen_text = original_chosen_text + custom_unit_in_chosen
+    
+    assert set(new_data[CHOSEN_TEXT_SENSORS]) == set(expected_chosen_text), \
+        f"CHOSEN_TEXT_SENSORS mismatch. Expected {set(expected_chosen_text)}, got {set(new_data[CHOSEN_TEXT_SENSORS])}"
+    
+    # Entries with custom unit that were in CHOSEN_FLOAT_SENSORS should be added
+    for custom_unit_key in custom_unit_entries:
+        if custom_unit_key in original_chosen_float:
+            assert custom_unit_key in new_data[CHOSEN_TEXT_SENSORS], \
+                f"Custom unit entry {custom_unit_key} should be added to CHOSEN_TEXT_SENSORS"
+    
+    # ===== Other Assertions =====
+    # Other fields should remain unchanged
+    assert new_data[CHOSEN_WRITABLE_SENSORS] == original_data[CHOSEN_WRITABLE_SENSORS]
+    assert new_data[WRITABLE_DICT] == original_data[WRITABLE_DICT]
+    assert new_data[FORCE_LEGACY_MODE] == original_data[FORCE_LEGACY_MODE]
+    
+    # Preserve additional config fields
+    assert "host" in new_data
+    assert "port" in new_data
+    
+    # ===== Options Merge Assertions =====
+    # Verify that options were merged into the migrated data
+    # The migrate_to_v6() function merges options into new_data before processing
+    assert new_options == {}, "Options should be empty after migration"

--- a/tests/fixtures/v5_config_data.json
+++ b/tests/fixtures/v5_config_data.json
@@ -1,0 +1,9895 @@
+{
+  "version": 5,
+  "entry_id": "01KFNX2WDA860TJQD7M1D9KJEE",
+  "data": {
+    "FLOAT_DICT": {
+      "eta_192_168_0_25__fbh_ausg\u00e4nge_heizkreismischer": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Ausg\u00e4nge > Heizkreismischer",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/11125/0",
+        "valid_values": null,
+        "value": 32.6
+      },
+      "eta_192_168_0_25__fbh_ausg\u00e4nge_heizkreismischer_ist_temperatur": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Ausg\u00e4nge > Heizkreismischer > Ist Temperatur",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/11125/2121",
+        "valid_values": null,
+        "value": 32.6
+      },
+      "eta_192_168_0_25__fbh_ausg\u00e4nge_heizkreismischer_laufzeit_mischer": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Ausg\u00e4nge > Heizkreismischer > Laufzeit Mischer",
+        "unit": "s",
+        "url": "/120/10102/0/11125/2124",
+        "valid_values": null,
+        "value": 120.0
+      },
+      "eta_192_168_0_25__fbh_ausg\u00e4nge_heizkreismischer_position": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Ausg\u00e4nge > Heizkreismischer > Position",
+        "unit": "%",
+        "url": "/120/10102/0/11125/2127",
+        "valid_values": null,
+        "value": 21.6
+      },
+      "eta_192_168_0_25__fbh_ausg\u00e4nge_heizkreismischer_soll_temperatur": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Ausg\u00e4nge > Heizkreismischer > Soll Temperatur",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/11125/2120",
+        "valid_values": null,
+        "value": 33.0
+      },
+      "eta_192_168_0_25__fbh_ausg\u00e4nge_pumpe": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Ausg\u00e4nge > Pumpe",
+        "unit": "%",
+        "url": "/120/10102/0/11687/0",
+        "valid_values": null,
+        "value": 60.0
+      },
+      "eta_192_168_0_25__fbh_ausg\u00e4nge_pumpe_ausgang": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Ausg\u00e4nge > Pumpe > Ausgang",
+        "unit": "%",
+        "url": "/120/10102/0/11687/2130",
+        "valid_values": null,
+        "value": 60.0
+      },
+      "eta_192_168_0_25__fbh_eing\u00e4nge_au\u00dfentemperatur": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Eing\u00e4nge > Au\u00dfentemperatur",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12197",
+        "valid_values": null,
+        "value": -1.3
+      },
+      "eta_192_168_0_25__fbh_eing\u00e4nge_vorlauf": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Eing\u00e4nge > Vorlauf",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/11060/0",
+        "valid_values": null,
+        "value": 32.6
+      },
+      "eta_192_168_0_25__fbh_eing\u00e4nge_vorlauf_fixwert": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Eing\u00e4nge > Vorlauf > Fixwert",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/11060/2054",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__fbh_eing\u00e4nge_vorlauf_kalibrierwert": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Eing\u00e4nge > Vorlauf > Kalibrierwert",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/11060/2049",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 5.0,
+          "scaled_min_value": -5.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_anforderungsdifferenz": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Anforderungsdifferenz",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12109",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 50.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 3.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_au\u00dfentemperatur_verz\u00f6gert": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Au\u00dfentemperatur verz\u00f6gert",
+        "unit": "\u00b0C",
+        "url": "/120/10102/12095/0/0",
+        "valid_values": null,
+        "value": -1.3
+      },
+      "eta_192_168_0_25__fbh_heizkreis_au\u00dfentemperatur_verz\u00f6gert_lag_tf": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Au\u00dfentemperatur verz\u00f6gert > Lag Tf",
+        "unit": "s",
+        "url": "/120/10102/12095/0/1074",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_au\u00dfentemperatur_verz\u00f6gert_lag_x": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Au\u00dfentemperatur verz\u00f6gert > Lag x",
+        "unit": "\u00b0C",
+        "url": "/120/10102/12095/0/1071",
+        "valid_values": null,
+        "value": -1.3
+      },
+      "eta_192_168_0_25__fbh_heizkreis_au\u00dfentemperatur_verz\u00f6gert_lag_y": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Au\u00dfentemperatur verz\u00f6gert > Lag y",
+        "unit": "\u00b0C",
+        "url": "/120/10102/12095/0/1073",
+        "valid_values": null,
+        "value": -1.3
+      },
+      "eta_192_168_0_25__fbh_heizkreis_estrich_absenkung_alle": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Estrich > Absenkung alle",
+        "unit": "s",
+        "url": "/120/10102/0/0/12310",
+        "valid_values": null,
+        "value": 86400.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_estrich_absenkung_um": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Estrich > Absenkung um",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12309",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 20.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 3.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_estrich_anschlie\u00dfende_heizpause": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Estrich > anschlie\u00dfende Heizpause",
+        "unit": "s",
+        "url": "/120/10102/0/0/14687",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_estrich_anstieg_alle": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Estrich > Anstieg alle",
+        "unit": "s",
+        "url": "/120/10102/0/0/12306",
+        "valid_values": null,
+        "value": 86400.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_estrich_anstieg_um": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Estrich > Anstieg um",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12305",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 20.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 3.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_estrich_erneute_max._temp._halten": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Estrich > erneute Max. Temp. halten",
+        "unit": "s",
+        "url": "/120/10102/0/0/14689",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_estrich_erneute_max._temperatur": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Estrich > erneute Max. Temperatur",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/14688",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 60.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_estrich_letzte_\u00e4nderung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Estrich > Letzte \u00c4nderung",
+        "unit": "s",
+        "url": "/120/10102/0/0/12311",
+        "valid_values": null,
+        "value": 141646000.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_estrich_max._temp._halten": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Estrich > Max. Temp. halten",
+        "unit": "s",
+        "url": "/120/10102/0/0/12308",
+        "valid_values": null,
+        "value": 345600.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_estrich_max._temperatur": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Estrich > Max. Temperatur",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12307",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 60.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 40.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_estrich_vorlauf_soll": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Estrich > Vorlauf Soll",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12304",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 60.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 15.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizgrenze_f\u00fcr_'absenken'": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizgrenze f\u00fcr 'Absenken'",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12097",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 50.0,
+          "scaled_min_value": -50.0
+        },
+        "value": 2.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizgrenze_f\u00fcr_'heizen'": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizgrenze f\u00fcr 'Heizen'",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/14116",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 50.0,
+          "scaled_min_value": -50.0
+        },
+        "value": 22.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizkreismischer": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizkreismischer",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/13620",
+        "valid_values": null,
+        "value": 32.5
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizkreispumpe_pumpendrehzahl": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizkreispumpe > Pumpendrehzahl",
+        "unit": "%",
+        "url": "/120/10102/0/0/12258",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 10.0
+        },
+        "value": 60.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizkurve": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizkurve",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12111",
+        "valid_values": null,
+        "value": 33.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizkurve_aus_bei_heizkurve_unter": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizkurve > Aus bei Heizkurve unter",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/14133",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 50.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 22.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizkurve_schieber_position": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizkurve > Schieber Position",
+        "unit": "%",
+        "url": "/120/10102/0/0/12240",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": -100.0
+        },
+        "value": 50.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizkurve_vorlauf_absenkung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizkurve > Vorlauf Absenkung",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12107",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 50.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 3.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizkurve_vorlauf_bei_+10\u00b0c": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizkurve > Vorlauf bei +10\u00b0C",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12103",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 25.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizkurve_vorlauf_bei_-10\u00b0c": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizkurve > Vorlauf bei -10\u00b0C",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12104",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 33.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizlast": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizlast",
+        "unit": "W",
+        "url": "/120/10102/0/0/13100",
+        "valid_values": null,
+        "value": 9851.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizlast_gesamtfl\u00e4che": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizlast > Gesamtfl\u00e4che",
+        "unit": "m\u00b2",
+        "url": "/120/10102/0/0/13096",
+        "valid_values": null,
+        "value": 171.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizlast_heizlast_w\u00e4hrend_estrichtrocknung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizlast > Heizlast w\u00e4hrend Estrichtrocknung",
+        "unit": "kW",
+        "url": "/120/10102/0/0/13600",
+        "valid_values": null,
+        "value": 12.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizlast_nennheizlast": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizlast > Nennheizlast",
+        "unit": "W",
+        "url": "/120/10102/0/0/13099",
+        "valid_values": null,
+        "value": 11970.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizlast_spez._heizlast": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizlast > spez. Heizlast",
+        "unit": "W/m\u00b2",
+        "url": "/120/10102/0/0/13098",
+        "valid_values": null,
+        "value": 70.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_r\u00fcckstellzeit_f._'kommen'-taste": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > R\u00fcckstellzeit f. 'Kommen'-Taste",
+        "unit": "s",
+        "url": "/120/10102/0/0/13796",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_vorlauf": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Vorlauf",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12241",
+        "valid_values": null,
+        "value": 32.6
+      },
+      "eta_192_168_0_25__fbh_heizkreis_vorlauf_vorlauf_max": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Vorlauf > Vorlauf Max",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12108",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 45.0
+      },
+      "eta_192_168_0_25__hk_eing\u00e4nge_au\u00dfentemperatur": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Eing\u00e4nge > Au\u00dfentemperatur",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12197",
+        "valid_values": null,
+        "value": -1.3
+      },
+      "eta_192_168_0_25__hk_heizkreis_au\u00dfentemperatur_verz\u00f6gert": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Au\u00dfentemperatur verz\u00f6gert",
+        "unit": "\u00b0C",
+        "url": "/120/10101/12095/0/0",
+        "valid_values": null,
+        "value": -1.3
+      },
+      "eta_192_168_0_25__hk_heizkreis_au\u00dfentemperatur_verz\u00f6gert_lag_tf": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Au\u00dfentemperatur verz\u00f6gert > Lag Tf",
+        "unit": "s",
+        "url": "/120/10101/12095/0/1074",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_au\u00dfentemperatur_verz\u00f6gert_lag_x": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Au\u00dfentemperatur verz\u00f6gert > Lag x",
+        "unit": "\u00b0C",
+        "url": "/120/10101/12095/0/1071",
+        "valid_values": null,
+        "value": -1.3
+      },
+      "eta_192_168_0_25__hk_heizkreis_au\u00dfentemperatur_verz\u00f6gert_lag_y": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Au\u00dfentemperatur verz\u00f6gert > Lag y",
+        "unit": "\u00b0C",
+        "url": "/120/10101/12095/0/1073",
+        "valid_values": null,
+        "value": -1.3
+      },
+      "eta_192_168_0_25__hk_heizkreis_estrich_absenkung_alle": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Estrich > Absenkung alle",
+        "unit": "s",
+        "url": "/120/10101/0/0/12310",
+        "valid_values": null,
+        "value": 86400.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_estrich_absenkung_um": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Estrich > Absenkung um",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12309",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 20.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 3.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_estrich_anschlie\u00dfende_heizpause": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Estrich > anschlie\u00dfende Heizpause",
+        "unit": "s",
+        "url": "/120/10101/0/0/14687",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_estrich_anstieg_alle": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Estrich > Anstieg alle",
+        "unit": "s",
+        "url": "/120/10101/0/0/12306",
+        "valid_values": null,
+        "value": 86400.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_estrich_anstieg_um": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Estrich > Anstieg um",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12305",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 20.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 3.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_estrich_erneute_max._temp._halten": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Estrich > erneute Max. Temp. halten",
+        "unit": "s",
+        "url": "/120/10101/0/0/14689",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_estrich_erneute_max._temperatur": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Estrich > erneute Max. Temperatur",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/14688",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 60.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_estrich_letzte_\u00e4nderung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Estrich > Letzte \u00c4nderung",
+        "unit": "s",
+        "url": "/120/10101/0/0/12311",
+        "valid_values": null,
+        "value": 141676000.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_estrich_max._temp._halten": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Estrich > Max. Temp. halten",
+        "unit": "s",
+        "url": "/120/10101/0/0/12308",
+        "valid_values": null,
+        "value": 345600.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_estrich_max._temperatur": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Estrich > Max. Temperatur",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12307",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 60.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 40.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_estrich_vorlauf_soll": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Estrich > Vorlauf Soll",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12304",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 60.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 15.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizgrenze_f\u00fcr_'absenken'": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizgrenze f\u00fcr 'Absenken'",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12097",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 50.0,
+          "scaled_min_value": -50.0
+        },
+        "value": 2.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizgrenze_f\u00fcr_'heizen'": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizgrenze f\u00fcr 'Heizen'",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/14116",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 50.0,
+          "scaled_min_value": -50.0
+        },
+        "value": 21.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizkurve": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizkurve",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12111",
+        "valid_values": null,
+        "value": 26.5
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizkurve_aus_bei_heizkurve_unter": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizkurve > Aus bei Heizkurve unter",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/14133",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 50.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 22.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizkurve_schieber_position": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizkurve > Schieber Position",
+        "unit": "%",
+        "url": "/120/10101/0/0/12240",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": -100.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizkurve_vorlauf_absenkung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizkurve > Vorlauf Absenkung",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12107",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 50.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 3.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizkurve_vorlauf_bei_+10\u00b0c": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizkurve > Vorlauf bei +10\u00b0C",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12103",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 25.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizkurve_vorlauf_bei_-10\u00b0c": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizkurve > Vorlauf bei -10\u00b0C",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12104",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 33.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizlast": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizlast",
+        "unit": "W",
+        "url": "/120/10101/0/0/13100",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizlast_gesamtfl\u00e4che": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizlast > Gesamtfl\u00e4che",
+        "unit": "m\u00b2",
+        "url": "/120/10101/0/0/13096",
+        "valid_values": null,
+        "value": 125.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizlast_heizlast_w\u00e4hrend_estrichtrocknung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizlast > Heizlast w\u00e4hrend Estrichtrocknung",
+        "unit": "kW",
+        "url": "/120/10101/0/0/13600",
+        "valid_values": null,
+        "value": 8.8
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizlast_nennheizlast": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizlast > Nennheizlast",
+        "unit": "W",
+        "url": "/120/10101/0/0/13099",
+        "valid_values": null,
+        "value": 8750.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizlast_spez._heizlast": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizlast > spez. Heizlast",
+        "unit": "W/m\u00b2",
+        "url": "/120/10101/0/0/13098",
+        "valid_values": null,
+        "value": 70.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_r\u00fcckstellzeit_f._'kommen'-taste": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > R\u00fcckstellzeit f. 'Kommen'-Taste",
+        "unit": "s",
+        "url": "/120/10101/0/0/13796",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_vorlauf_vorlauf_max": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Vorlauf > Vorlauf Max",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12108",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 45.0
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_abgasgebl\u00e4se": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Abgasgebl\u00e4se",
+        "unit": "U/min",
+        "url": "/40/10021/0/0/12165",
+        "valid_values": null,
+        "value": 1180.0
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_abgasgebl\u00e4se_abgasgebl\u00e4se_ist_drehzahl": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Abgasgebl\u00e4se > Abgasgebl\u00e4se > Ist Drehzahl",
+        "unit": "U/min",
+        "url": "/40/10021/0/11120/2111",
+        "valid_values": null,
+        "value": 1184.0
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_abgasgebl\u00e4se_abgasgebl\u00e4se_soll_drehzahl": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Abgasgebl\u00e4se > Abgasgebl\u00e4se > Soll Drehzahl",
+        "unit": "U/min",
+        "url": "/40/10021/0/11120/2110",
+        "valid_values": null,
+        "value": 1184.0
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_kesselpumpe": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Kesselpumpe",
+        "unit": "%",
+        "url": "/40/10021/0/11123/0",
+        "valid_values": null,
+        "value": 65.3
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_kesselpumpe_ausgang": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Kesselpumpe > Ausgang",
+        "unit": "%",
+        "url": "/40/10021/0/11123/2130",
+        "valid_values": null,
+        "value": 65.3
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_luftschieber": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Luftschieber",
+        "unit": "%",
+        "url": "/40/10021/0/11115/0",
+        "valid_values": null,
+        "value": 0.6
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_luftschieber_ist_stellung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Luftschieber > Ist Stellung",
+        "unit": "%",
+        "url": "/40/10021/0/11115/2071",
+        "valid_values": null,
+        "value": 0.6
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_luftschieber_soll_stellung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Luftschieber > Soll Stellung",
+        "unit": "%",
+        "url": "/40/10021/0/11115/2070",
+        "valid_values": null,
+        "value": 100.0
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_stokerschnecke": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Stokerschnecke",
+        "unit": "%",
+        "url": "/40/10021/0/11030/0",
+        "valid_values": null,
+        "value": 22.3
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_stokerschnecke_erw\u00e4rmung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Stokerschnecke > Erw\u00e4rmung",
+        "unit": "%",
+        "url": "/40/10021/0/11030/2092",
+        "valid_values": null,
+        "value": 33.3
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_stokerschnecke_motor_strom": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Stokerschnecke > Motor Strom",
+        "unit": "A",
+        "url": "/40/10021/0/11030/2091",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_stokerschnecke_motor_strom_maximal_strom": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Stokerschnecke > Motor Strom > Maximal Strom",
+        "unit": "A",
+        "url": "/40/10021/0/11030/2096",
+        "valid_values": null,
+        "value": 0.18
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_stokerschnecke_motor_strom_mindest_strom": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Stokerschnecke > Motor Strom > Mindest Strom",
+        "unit": "A",
+        "url": "/40/10021/0/11030/2097",
+        "valid_values": null,
+        "value": 0.02
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_stokerschnecke_motor_strom_nennstrom": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Stokerschnecke > Motor Strom > Nennstrom",
+        "unit": "A",
+        "url": "/40/10021/0/11030/2098",
+        "valid_values": null,
+        "value": 0.165
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_stokerschnecke_schneckendrehzahl": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Stokerschnecke > Schneckendrehzahl",
+        "unit": "U/min",
+        "url": "/40/10021/0/11030/2099",
+        "valid_values": null,
+        "value": 2.0
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_stokerschnecke_taktrate": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Stokerschnecke > Taktrate",
+        "unit": "%",
+        "url": "/40/10021/0/11030/2090",
+        "valid_values": null,
+        "value": 22.3
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_umschaltventil_laufzeit": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Umschaltventil > Laufzeit",
+        "unit": "s",
+        "url": "/40/10021/0/0/12040",
+        "valid_values": null,
+        "value": 135.0
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_vorlaufmischer_1": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Vorlaufmischer 1",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11121/0",
+        "valid_values": null,
+        "value": 61.1
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_vorlaufmischer_1_ist_temperatur": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Vorlaufmischer 1 > Ist Temperatur",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11121/2121",
+        "valid_values": null,
+        "value": 61.1
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_vorlaufmischer_1_laufzeit_mischer": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Vorlaufmischer 1 > Laufzeit Mischer",
+        "unit": "s",
+        "url": "/40/10021/0/11121/2124",
+        "valid_values": null,
+        "value": 135.0
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_vorlaufmischer_1_position": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Vorlaufmischer 1 > Position",
+        "unit": "%",
+        "url": "/40/10021/0/11121/2127",
+        "valid_values": null,
+        "value": 56.4
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_vorlaufmischer_1_soll_temperatur": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Vorlaufmischer 1 > Soll Temperatur",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11121/2120",
+        "valid_values": null,
+        "value": 61.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_abgas": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Abgas",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11110/0",
+        "valid_values": null,
+        "value": 106.8
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_abgas_fixwert": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Abgas > Fixwert",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11110/2054",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 200.0,
+          "scaled_min_value": -100.0
+        },
+        "value": 120.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_abgas_kalibrierwert": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Abgas > Kalibrierwert",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11110/2049",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 5.0,
+          "scaled_min_value": -5.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_aschebox_ausschalt_verz.": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Aschebox > Ausschalt Verz.",
+        "unit": "s",
+        "url": "/40/10021/0/11034/2013",
+        "valid_values": null,
+        "value": 1.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_aschebox_einschalt_verz.": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Aschebox > Einschalt Verz.",
+        "unit": "s",
+        "url": "/40/10021/0/11034/2012",
+        "valid_values": null,
+        "value": 1.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_glutbett_ausschalt_verz.": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Glutbett > Ausschalt Verz.",
+        "unit": "s",
+        "url": "/40/10021/0/11036/2013",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_glutbett_einschalt_verz.": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Glutbett > Einschalt Verz.",
+        "unit": "s",
+        "url": "/40/10021/0/11036/2012",
+        "valid_values": null,
+        "value": 5.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11109/0",
+        "valid_values": null,
+        "value": 66.4
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel_fixwert": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel > Fixwert",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11109/2054",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 200.0,
+          "scaled_min_value": -100.0
+        },
+        "value": 70.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel_kalibrierwert": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel > Kalibrierwert",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11109/2049",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 5.0,
+          "scaled_min_value": -5.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel_unten": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel unten",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11122/0",
+        "valid_values": null,
+        "value": 55.9
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel_unten_fixwert": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel unten > Fixwert",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11122/2054",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 200.0,
+          "scaled_min_value": -100.0
+        },
+        "value": 55.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel_unten_kalibrierwert": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel unten > Kalibrierwert",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11122/2049",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 5.0,
+          "scaled_min_value": -5.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel_vorlauf_1": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel Vorlauf 1",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11058/0",
+        "valid_values": null,
+        "value": 61.4
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel_vorlauf_1_fixwert": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel Vorlauf 1 > Fixwert",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11058/2054",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 200.0,
+          "scaled_min_value": -100.0
+        },
+        "value": 60.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel_vorlauf_1_kalibrierwert": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel Vorlauf 1 > Kalibrierwert",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11058/2049",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 5.0,
+          "scaled_min_value": -5.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kesseldruck": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kesseldruck",
+        "unit": "bar",
+        "url": "/40/10021/0/0/12180",
+        "valid_values": null,
+        "value": 1.36
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kesseldruck_kesseldruck": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kesseldruck > Kesseldruck",
+        "unit": "V",
+        "url": "/40/10021/0/11135/0",
+        "valid_values": null,
+        "value": 1.52
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_messblende": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Messblende",
+        "unit": "Pa",
+        "url": "/40/10021/0/0/12166",
+        "valid_values": null,
+        "value": 7.5
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_messblende_messblende": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Messblende > Messblende",
+        "unit": "V",
+        "url": "/40/10021/0/11134/0",
+        "valid_values": null,
+        "value": 0.66
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_messblende_mindestdruck": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Messblende > Mindestdruck",
+        "unit": "Pa",
+        "url": "/40/10021/0/0/12150",
+        "valid_values": null,
+        "value": 10.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_messblende_offset": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Messblende > Offset",
+        "unit": "Pa",
+        "url": "/40/10021/0/0/12167",
+        "valid_values": null,
+        "value": -4.5
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_not-aus_schalter_ausschalt_verz.": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Not-Aus Schalter > Ausschalt Verz.",
+        "unit": "s",
+        "url": "/40/10021/0/11032/2013",
+        "valid_values": null,
+        "value": 1.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_not-aus_schalter_einschalt_verz.": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Not-Aus Schalter > Einschalt Verz.",
+        "unit": "s",
+        "url": "/40/10021/0/11032/2012",
+        "valid_values": null,
+        "value": 1.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_pelletsbeh\u00e4lter_ausschalt_verz.": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Pelletsbeh\u00e4lter > Ausschalt Verz.",
+        "unit": "s",
+        "url": "/40/10021/0/11037/2013",
+        "valid_values": null,
+        "value": 1.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_pelletsbeh\u00e4lter_einschalt_verz.": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Pelletsbeh\u00e4lter > Einschalt Verz.",
+        "unit": "s",
+        "url": "/40/10021/0/11037/2012",
+        "valid_values": null,
+        "value": 1.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_restsauerstoff": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Restsauerstoff",
+        "unit": "%",
+        "url": "/40/10021/0/11108/0",
+        "valid_values": null,
+        "value": 8.3
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_restsauerstoff_heizspannung_ist": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Restsauerstoff > Heizspannung Ist",
+        "unit": "V",
+        "url": "/40/10021/0/11108/2069",
+        "valid_values": null,
+        "value": 14.042
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_restsauerstoff_innenwiderstand": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Restsauerstoff > Innenwiderstand",
+        "unit": "Ohm",
+        "url": "/40/10021/0/11108/2058",
+        "valid_values": null,
+        "value": 201.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_restsauerstoff_kalibrierung_kalibrier_intervall": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Restsauerstoff > Kalibrierung > Kalibrier Intervall",
+        "unit": "s",
+        "url": "/40/10021/0/0/12246",
+        "valid_values": null,
+        "value": 1800000.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_restsauerstoff_kalibrierung_letzte_kalibrierung_bei": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Restsauerstoff > Kalibrierung > Letzte Kalibrierung bei",
+        "unit": "s",
+        "url": "/40/10021/0/0/12247",
+        "valid_values": null,
+        "value": 51977500.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_restsauerstoff_kalibrierwert": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Restsauerstoff > Kalibrierwert",
+        "unit": "mV",
+        "url": "/40/10021/0/11108/2064",
+        "valid_values": null,
+        "value": 2.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_restsauerstoff_korrigiertes_signal": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Restsauerstoff > korrigiertes Signal",
+        "unit": "mV",
+        "url": "/40/10021/0/11108/2065",
+        "valid_values": null,
+        "value": 8.9
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_restsauerstoff_restsauerstoff": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Restsauerstoff > Restsauerstoff",
+        "unit": "%",
+        "url": "/40/10021/0/11108/2060",
+        "valid_values": null,
+        "value": 8.02
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_restsauerstoff_signal": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Restsauerstoff > Signal",
+        "unit": "mV",
+        "url": "/40/10021/0/11108/2066",
+        "valid_values": null,
+        "value": 6.1
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_restsauerstoff_verz\u00f6gerung_(tf)": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Restsauerstoff > Verz\u00f6gerung (Tf)",
+        "unit": "s",
+        "url": "/40/10021/0/11108/2053",
+        "valid_values": null,
+        "value": 1.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_stb_ausschalt_verz.": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > STB > Ausschalt Verz.",
+        "unit": "s",
+        "url": "/40/10021/0/11033/2013",
+        "valid_values": null,
+        "value": 1.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_stb_einschalt_verz.": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > STB > Einschalt Verz.",
+        "unit": "s",
+        "url": "/40/10021/0/11033/2012",
+        "valid_values": null,
+        "value": 1.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_wassermangel_ausschalt_verz.": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Wassermangel > Ausschalt Verz.",
+        "unit": "s",
+        "url": "/40/10021/0/11031/2013",
+        "valid_values": null,
+        "value": 1.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_wassermangel_einschalt_verz.": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Wassermangel > Einschalt Verz.",
+        "unit": "s",
+        "url": "/40/10021/0/11031/2012",
+        "valid_values": null,
+        "value": 1.0
+      },
+      "eta_192_168_0_25__kessel_kessel_abgas": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Abgas",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/0/12162",
+        "valid_values": null,
+        "value": 106.7
+      },
+      "eta_192_168_0_25__kessel_kessel_abgas_abgas_max": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Abgas > Abgas Max",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/0/12023",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 300.0,
+          "scaled_min_value": 100.0
+        },
+        "value": 180.0
+      },
+      "eta_192_168_0_25__kessel_kessel_abgas_emissionsmessung_dauer_der_messung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Abgas > Emissionsmessung > Dauer der Messung",
+        "unit": "s",
+        "url": "/40/10021/0/0/12118",
+        "valid_values": null,
+        "value": 2700.0
+      },
+      "eta_192_168_0_25__kessel_kessel_abgas_emissionsmessung_verriegelungsdauer": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Abgas > Emissionsmessung > Verriegelungsdauer",
+        "unit": "s",
+        "url": "/40/10021/0/0/13268",
+        "valid_values": null,
+        "value": 14400.0
+      },
+      "eta_192_168_0_25__kessel_kessel_abgas_emissionsmessung_vorw\u00e4rmdauer": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Abgas > Emissionsmessung > Vorw\u00e4rmdauer",
+        "unit": "s",
+        "url": "/40/10021/0/0/13481",
+        "valid_values": null,
+        "value": 1800.0
+      },
+      "eta_192_168_0_25__kessel_kessel_einschub": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Einschub",
+        "unit": "%",
+        "url": "/40/10021/0/0/12007",
+        "valid_values": null,
+        "value": 22.3
+      },
+      "eta_192_168_0_25__kessel_kessel_einschub_brennstoffverst\u00e4rkung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Einschub > Brennstoffverst\u00e4rkung",
+        "unit": "%",
+        "url": "/40/10021/0/0/12069",
+        "valid_values": null,
+        "value": 112.2
+      },
+      "eta_192_168_0_25__kessel_kessel_einschub_stoker_sekunden_pro_kg": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Einschub > Stoker Sekunden pro kg",
+        "unit": "s",
+        "url": "/40/10021/0/0/12043",
+        "valid_values": null,
+        "value": 580.0
+      },
+      "eta_192_168_0_25__kessel_kessel_entaschung_aschebox_leeren_nach": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Entaschung > Aschebox leeren nach",
+        "unit": "kg",
+        "url": "/40/10021/0/0/12120",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 5000.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 1000.0
+      },
+      "eta_192_168_0_25__kessel_kessel_entaschung_beginn_ruhezeit": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Entaschung > Beginn Ruhezeit",
+        "unit": "minutes_since_midnight",
+        "url": "/40/10021/0/0/12248",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 1,
+          "scaled_max_value": 1439.0,
+          "scaled_min_value": 0.0
+        },
+        "value": "21:00"
+      },
+      "eta_192_168_0_25__kessel_kessel_entaschung_dauer_ruhezeit": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Entaschung > Dauer Ruhezeit",
+        "unit": "s",
+        "url": "/40/10021/0/0/12249",
+        "valid_values": null,
+        "value": 36000.0
+      },
+      "eta_192_168_0_25__kessel_kessel_entaschung_entaschen_nach_max.": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Entaschung > Entaschen nach max.",
+        "unit": "kg",
+        "url": "/40/10021/0/0/12074",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 25.0
+      },
+      "eta_192_168_0_25__kessel_kessel_entaschung_entaschen_nach_min.": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Entaschung > Entaschen nach min.",
+        "unit": "kg",
+        "url": "/40/10021/0/0/12073",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 15.0
+      },
+      "eta_192_168_0_25__kessel_kessel_kessel": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Kessel",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/0/12161",
+        "valid_values": null,
+        "value": 65.6
+      },
+      "eta_192_168_0_25__kessel_kessel_kessel_ausschaltdifferenz": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Kessel > Ausschaltdifferenz",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/0/12141",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 40.0,
+          "scaled_min_value": 3.0
+        },
+        "value": 15.0
+      },
+      "eta_192_168_0_25__kessel_kessel_kessel_kessel_min": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Kessel > Kessel Min",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/0/12022",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 50.0
+        },
+        "value": 55.0
+      },
+      "eta_192_168_0_25__kessel_kessel_kessel_kessel_soll": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Kessel > Kessel Soll",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/0/12001",
+        "valid_values": null,
+        "value": 66.0
+      },
+      "eta_192_168_0_25__kessel_kessel_kessel_mindest_laufzeit": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Kessel > Mindest Laufzeit",
+        "unit": "s",
+        "url": "/40/10021/0/0/12226",
+        "valid_values": null,
+        "value": 1800.0
+      },
+      "eta_192_168_0_25__kessel_kessel_kessel_unten": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Kessel unten",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/0/12300",
+        "valid_values": null,
+        "value": 55.7
+      },
+      "eta_192_168_0_25__kessel_kessel_kesseldruck_maximaler_wasserdruck": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Kesseldruck > Maximaler Wasserdruck",
+        "unit": "bar",
+        "url": "/40/10021/0/0/12171",
+        "valid_values": null,
+        "value": 2.8
+      },
+      "eta_192_168_0_25__kessel_kessel_kesseldruck_mindestdruck": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Kesseldruck > Mindestdruck",
+        "unit": "bar",
+        "url": "/40/10021/0/0/12170",
+        "valid_values": null,
+        "value": 0.8
+      },
+      "eta_192_168_0_25__kessel_kessel_kesseldruck_wasserdruck_nachf\u00fcllen_ab": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Kesseldruck > Wasserdruck Nachf\u00fcllen ab",
+        "unit": "bar",
+        "url": "/40/10021/0/0/12172",
+        "valid_values": null,
+        "value": 1.2
+      },
+      "eta_192_168_0_25__kessel_kessel_kessellaufmeldung_nachlaufzeit": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Kessellaufmeldung > Nachlaufzeit",
+        "unit": "s",
+        "url": "/40/10021/0/0/12110",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__kessel_kessel_kesselpumpe_maximal_drehzahl": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Kesselpumpe > Maximal Drehzahl",
+        "unit": "%",
+        "url": "/40/10021/0/0/12368",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 10.0
+        },
+        "value": 100.0
+      },
+      "eta_192_168_0_25__kessel_kessel_kesselpumpe_mindest_drehzahl": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Kesselpumpe > Mindest Drehzahl",
+        "unit": "%",
+        "url": "/40/10021/0/0/12227",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 10.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__kessel_kessel_pelletsbeh\u00e4lter_berechnete_saugzeit_max": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Pelletsbeh\u00e4lter > berechnete Saugzeit Max",
+        "unit": "s",
+        "url": "/40/10021/0/0/14635",
+        "valid_values": null,
+        "value": 188.0
+      },
+      "eta_192_168_0_25__kessel_kessel_pelletsbeh\u00e4lter_nachlauf_austragschnecke": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Pelletsbeh\u00e4lter > Nachlauf Austragschnecke",
+        "unit": "s",
+        "url": "/40/10021/0/0/12064",
+        "valid_values": null,
+        "value": 2.0
+      },
+      "eta_192_168_0_25__kessel_kessel_pelletsbeh\u00e4lter_saugzeit_max": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Pelletsbeh\u00e4lter > Saugzeit Max",
+        "unit": "s",
+        "url": "/40/10021/0/0/12061",
+        "valid_values": null,
+        "value": 360.0
+      },
+      "eta_192_168_0_25__kessel_kessel_pelletsbeh\u00e4lter_saugzeitpunkt": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Pelletsbeh\u00e4lter > Saugzeitpunkt",
+        "unit": "minutes_since_midnight",
+        "url": "/40/10021/0/0/12152",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 1,
+          "scaled_max_value": 1439.0,
+          "scaled_min_value": 0.0
+        },
+        "value": "19:00"
+      },
+      "eta_192_168_0_25__kessel_kessel_restsauerstoff": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Restsauerstoff",
+        "unit": "%",
+        "url": "/40/10021/0/0/12164",
+        "valid_values": null,
+        "value": 9.39
+      },
+      "eta_192_168_0_25__kessel_kessel_restsauerstoff_o2_soll": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Restsauerstoff > O2 Soll",
+        "unit": "%",
+        "url": "/40/10021/12004/0/0",
+        "valid_values": null,
+        "value": 8.94
+      },
+      "eta_192_168_0_25__kessel_kessel_restsauerstoff_o2_soll_lin_x": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Restsauerstoff > O2 Soll > Lin x",
+        "unit": "%",
+        "url": "/40/10021/12004/0/1050",
+        "valid_values": null,
+        "value": 45.9
+      },
+      "eta_192_168_0_25__kessel_kessel_restsauerstoff_o2_soll_lin_x1": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Restsauerstoff > O2 Soll > Lin x1",
+        "unit": "%",
+        "url": "/40/10021/12004/0/1051",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 30.0,
+          "scaled_min_value": 30.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__kessel_kessel_restsauerstoff_o2_soll_lin_x2": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Restsauerstoff > O2 Soll > Lin x2",
+        "unit": "%",
+        "url": "/40/10021/12004/0/1053",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 100.0
+        },
+        "value": 100.0
+      },
+      "eta_192_168_0_25__kessel_kessel_restsauerstoff_o2_soll_lin_y": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Restsauerstoff > O2 Soll > Lin y",
+        "unit": "%",
+        "url": "/40/10021/12004/0/1055",
+        "valid_values": null,
+        "value": 8.94
+      },
+      "eta_192_168_0_25__kessel_kessel_restsauerstoff_o2_soll_lin_y1": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Restsauerstoff > O2 Soll > Lin y1",
+        "unit": "%",
+        "url": "/40/10021/12004/0/1052",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 100,
+          "scaled_max_value": 15.0,
+          "scaled_min_value": 7.0
+        },
+        "value": 9.5
+      },
+      "eta_192_168_0_25__kessel_kessel_restsauerstoff_o2_soll_lin_y2": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Restsauerstoff > O2 Soll > Lin y2",
+        "unit": "%",
+        "url": "/40/10021/12004/0/1054",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 100,
+          "scaled_max_value": 15.0,
+          "scaled_min_value": 6.0
+        },
+        "value": 7.0
+      },
+      "eta_192_168_0_25__kessel_kessel_vorlaufregler_1_anforderungsdifferenz": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Vorlaufregler 1 > Anforderungsdifferenz",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/0/12020",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 20.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 5.0
+      },
+      "eta_192_168_0_25__kessel_kessel_vorlaufregler_1_angeforderte_leistung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Vorlaufregler 1 > Angeforderte Leistung",
+        "unit": "kW",
+        "url": "/40/10021/0/0/12077",
+        "valid_values": null,
+        "value": 9.8
+      },
+      "eta_192_168_0_25__kessel_kessel_vorlaufregler_1_angeforderte_temperatur": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Vorlaufregler 1 > Angeforderte Temperatur",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/0/12006",
+        "valid_values": null,
+        "value": 61.0
+      },
+      "eta_192_168_0_25__kessel_kessel_z\u00fcndung_heizversuch_max": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Z\u00fcndung > Heizversuch Max",
+        "unit": "s",
+        "url": "/40/10021/0/0/12046",
+        "valid_values": null,
+        "value": 300.0
+      },
+      "eta_192_168_0_25__kessel_kessel_z\u00fcndung_maximale_z\u00fcnddauer": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Z\u00fcndung > Maximale Z\u00fcnddauer",
+        "unit": "s",
+        "url": "/40/10021/0/0/12048",
+        "valid_values": null,
+        "value": 900.0
+      },
+      "eta_192_168_0_25__kessel_kessel_z\u00fcndung_warmstart_zeit": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Z\u00fcndung > Warmstart Zeit",
+        "unit": "s",
+        "url": "/40/10021/0/0/12045",
+        "valid_values": null,
+        "value": 1800.0
+      },
+      "eta_192_168_0_25__kessel_z\u00e4hlerst\u00e4nde_gesamtverbrauch": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Z\u00e4hlerst\u00e4nde > Gesamtverbrauch",
+        "unit": "kg",
+        "url": "/40/10021/0/0/12016",
+        "valid_values": null,
+        "value": 13349.7
+      },
+      "eta_192_168_0_25__kessel_z\u00e4hlerst\u00e4nde_inhalt_pelletsbeh\u00e4lter": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Z\u00e4hlerst\u00e4nde > Inhalt Pelletsbeh\u00e4lter",
+        "unit": "kg",
+        "url": "/40/10021/0/0/12011",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 0.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 28.8
+      },
+      "eta_192_168_0_25__kessel_z\u00e4hlerst\u00e4nde_laufzeit_abgasgebl\u00e4se": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Z\u00e4hlerst\u00e4nde > Laufzeit Abgasgebl\u00e4se",
+        "unit": "s",
+        "url": "/40/10021/0/0/12299",
+        "valid_values": null,
+        "value": 52630300.0
+      },
+      "eta_192_168_0_25__kessel_z\u00e4hlerst\u00e4nde_laufzeit_entaschung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Z\u00e4hlerst\u00e4nde > Laufzeit Entaschung",
+        "unit": "s",
+        "url": "/40/10021/0/0/12155",
+        "valid_values": null,
+        "value": 355450.0
+      },
+      "eta_192_168_0_25__kessel_z\u00e4hlerst\u00e4nde_laufzeit_saugturbine": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Z\u00e4hlerst\u00e4nde > Laufzeit Saugturbine",
+        "unit": "s",
+        "url": "/40/10021/0/0/12157",
+        "valid_values": null,
+        "value": 54068.0
+      },
+      "eta_192_168_0_25__kessel_z\u00e4hlerst\u00e4nde_laufzeit_stoker": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Z\u00e4hlerst\u00e4nde > Laufzeit Stoker",
+        "unit": "s",
+        "url": "/40/10021/0/0/12154",
+        "valid_values": null,
+        "value": 7743040.0
+      },
+      "eta_192_168_0_25__kessel_z\u00e4hlerst\u00e4nde_laufzeit_z\u00fcndung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Z\u00e4hlerst\u00e4nde > Laufzeit Z\u00fcndung",
+        "unit": "s",
+        "url": "/40/10021/0/0/12156",
+        "valid_values": null,
+        "value": 2096940.0
+      },
+      "eta_192_168_0_25__kessel_z\u00e4hlerst\u00e4nde_laufzeit_z\u00fcndung_dauer_der_letzten_z\u00fcndung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Z\u00e4hlerst\u00e4nde > Laufzeit Z\u00fcndung > Dauer der letzten Z\u00fcndung",
+        "unit": "s",
+        "url": "/40/10021/0/0/13346",
+        "valid_values": null,
+        "value": 139.0
+      },
+      "eta_192_168_0_25__kessel_z\u00e4hlerst\u00e4nde_verbrauch_seit_aschebox_leeren": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Z\u00e4hlerst\u00e4nde > Verbrauch seit Aschebox leeren",
+        "unit": "kg",
+        "url": "/40/10021/0/0/12013",
+        "valid_values": null,
+        "value": 574.9
+      },
+      "eta_192_168_0_25__kessel_z\u00e4hlerst\u00e4nde_verbrauch_seit_entaschung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Z\u00e4hlerst\u00e4nde > Verbrauch seit Entaschung",
+        "unit": "kg",
+        "url": "/40/10021/0/0/12012",
+        "valid_values": null,
+        "value": 23.4
+      },
+      "eta_192_168_0_25__kessel_z\u00e4hlerst\u00e4nde_verbrauch_seit_wartung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Z\u00e4hlerst\u00e4nde > Verbrauch seit Wartung",
+        "unit": "kg",
+        "url": "/40/10021/0/0/12014",
+        "valid_values": null,
+        "value": 1593.2
+      },
+      "eta_192_168_0_25__kessel_z\u00e4hlerst\u00e4nde_volllaststunden": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Z\u00e4hlerst\u00e4nde > Volllaststunden",
+        "unit": "s",
+        "url": "/40/10021/0/0/12153",
+        "valid_values": null,
+        "value": 24918200.0
+      },
+      "eta_192_168_0_25__kessel_z\u00e4hlerst\u00e4nde_z\u00e4hler_sicherheitspumpenlauf_laufzeit_sicherheitspumpenlauf": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Z\u00e4hlerst\u00e4nde > Z\u00e4hler Sicherheitspumpenlauf > Laufzeit Sicherheitspumpenlauf",
+        "unit": "s",
+        "url": "/40/10021/0/0/13643",
+        "valid_values": null,
+        "value": 52579.0
+      },
+      "eta_192_168_0_25__lagerum._austragung_sp\u00fcldauer": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "LagerUm. > Austragung > Sp\u00fcldauer",
+        "unit": "s",
+        "url": "/40/10211/0/0/12261",
+        "valid_values": null,
+        "value": 60.0
+      },
+      "eta_192_168_0_25__lagerum._eing\u00e4nge_nullpunktschalter_ausschalt_verz.": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "LagerUm. > Eing\u00e4nge > Nullpunktschalter > Ausschalt Verz.",
+        "unit": "s",
+        "url": "/40/10211/0/11133/2013",
+        "valid_values": null,
+        "value": 1.0
+      },
+      "eta_192_168_0_25__lagerum._eing\u00e4nge_nullpunktschalter_einschalt_verz.": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "LagerUm. > Eing\u00e4nge > Nullpunktschalter > Einschalt Verz.",
+        "unit": "s",
+        "url": "/40/10211/0/11133/2012",
+        "valid_values": null,
+        "value": 1.0
+      },
+      "eta_192_168_0_25__lagerum._vorrat": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "LagerUm. > Vorrat",
+        "unit": "kg",
+        "url": "/40/10211/0/0/12015",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100000.0,
+          "scaled_min_value": -100000.0
+        },
+        "value": 2728.9
+      },
+      "eta_192_168_0_25__lagerum._vorrat_vorrat_warngrenze": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "LagerUm. > Vorrat > Vorrat Warngrenze",
+        "unit": "kg",
+        "url": "/40/10211/0/0/12042",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100000.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 1000.0
+      },
+      "eta_192_168_0_25__sys_antiblockierschutz_zu_welcher_uhrzeit?": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Sys > Antiblockierschutz > zu welcher Uhrzeit?",
+        "unit": "minutes_since_midnight",
+        "url": "/120/10241/0/0/14244",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 1,
+          "scaled_max_value": 1439.0,
+          "scaled_min_value": 0.0
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__sys_au\u00dfentemperatur": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Sys > Au\u00dfentemperatur",
+        "unit": "\u00b0C",
+        "url": "/120/10241/0/0/12197",
+        "valid_values": null,
+        "value": -1.3
+      },
+      "eta_192_168_0_25__sys_au\u00dfentemperatur_au\u00dfentemperaturf\u00fchler": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Sys > Au\u00dfentemperatur > Au\u00dfentemperaturf\u00fchler",
+        "unit": "\u00b0C",
+        "url": "/120/10241/0/11127/0",
+        "valid_values": null,
+        "value": -1.3
+      },
+      "eta_192_168_0_25__sys_au\u00dfentemperatur_au\u00dfentemperaturf\u00fchler_fixwert": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Sys > Au\u00dfentemperatur > Au\u00dfentemperaturf\u00fchler > Fixwert",
+        "unit": "\u00b0C",
+        "url": "/120/10241/0/11127/2054",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 200.0,
+          "scaled_min_value": -100.0
+        },
+        "value": -5.0
+      },
+      "eta_192_168_0_25__sys_au\u00dfentemperatur_au\u00dfentemperaturf\u00fchler_kalibrierwert": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Sys > Au\u00dfentemperatur > Au\u00dfentemperaturf\u00fchler > Kalibrierwert",
+        "unit": "\u00b0C",
+        "url": "/120/10241/0/11127/2049",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 5.0,
+          "scaled_min_value": -5.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_eing\u00e4nge_warmwasserspeicher": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Eing\u00e4nge > Warmwasserspeicher",
+        "unit": "\u00b0C",
+        "url": "/120/10111/0/11129/0",
+        "valid_values": null,
+        "value": 57.3
+      },
+      "eta_192_168_0_25__ww_eing\u00e4nge_warmwasserspeicher_fixwert": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Eing\u00e4nge > Warmwasserspeicher > Fixwert",
+        "unit": "\u00b0C",
+        "url": "/120/10111/0/11129/2054",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 200.0,
+          "scaled_min_value": -100.0
+        },
+        "value": 53.0
+      },
+      "eta_192_168_0_25__ww_eing\u00e4nge_warmwasserspeicher_kalibrierwert": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Eing\u00e4nge > Warmwasserspeicher > Kalibrierwert",
+        "unit": "\u00b0C",
+        "url": "/120/10111/0/11129/2049",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 5.0,
+          "scaled_min_value": -5.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_einschaltdifferenz": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Einschaltdifferenz",
+        "unit": "\u00b0C",
+        "url": "/120/10111/0/0/12133",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 30.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 20.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_laden_mit_anderen_verbrauchern_einschaltdifferenz": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Laden mit anderen Verbrauchern > Einschaltdifferenz",
+        "unit": "\u00b0C",
+        "url": "/120/10111/0/0/13535",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 30.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 5.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_dienstag_wert_au\u00dferhalb_der_zeitfenster": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Dienstag > Wert au\u00dferhalb der Zeitfenster",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1112",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_dienstag_zeitfenster_1": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Dienstag > Zeitfenster 1",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1086",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_dienstag_zeitfenster_2": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Dienstag > Zeitfenster 2",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1087",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_dienstag_zeitfenster_3": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Dienstag > Zeitfenster 3",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1088",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_donnerstag_wert_au\u00dferhalb_der_zeitfenster": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Donnerstag > Wert au\u00dferhalb der Zeitfenster",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1114",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_donnerstag_zeitfenster_1": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Donnerstag > Zeitfenster 1",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1094",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_donnerstag_zeitfenster_2": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Donnerstag > Zeitfenster 2",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1095",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_donnerstag_zeitfenster_3": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Donnerstag > Zeitfenster 3",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1096",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_freitag_wert_au\u00dferhalb_der_zeitfenster": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Freitag > Wert au\u00dferhalb der Zeitfenster",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1115",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_freitag_zeitfenster_1": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Freitag > Zeitfenster 1",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1098",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_freitag_zeitfenster_2": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Freitag > Zeitfenster 2",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1099",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_freitag_zeitfenster_3": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Freitag > Zeitfenster 3",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1100",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_mittwoch_wert_au\u00dferhalb_der_zeitfenster": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Mittwoch > Wert au\u00dferhalb der Zeitfenster",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1113",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_mittwoch_zeitfenster_1": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Mittwoch > Zeitfenster 1",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1090",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_mittwoch_zeitfenster_2": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Mittwoch > Zeitfenster 2",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1091",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_mittwoch_zeitfenster_3": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Mittwoch > Zeitfenster 3",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1092",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_montag_wert_au\u00dferhalb_der_zeitfenster": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Montag > Wert au\u00dferhalb der Zeitfenster",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1111",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_montag_zeitfenster_1": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Montag > Zeitfenster 1",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1082",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_montag_zeitfenster_2": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Montag > Zeitfenster 2",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1083",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_montag_zeitfenster_3": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Montag > Zeitfenster 3",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1084",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_samstag_wert_au\u00dferhalb_der_zeitfenster": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Samstag > Wert au\u00dferhalb der Zeitfenster",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1116",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_samstag_zeitfenster_1": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Samstag > Zeitfenster 1",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1102",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_samstag_zeitfenster_2": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Samstag > Zeitfenster 2",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1103",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_samstag_zeitfenster_3": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Samstag > Zeitfenster 3",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1104",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_sonntag_wert_au\u00dferhalb_der_zeitfenster": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Sonntag > Wert au\u00dferhalb der Zeitfenster",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1117",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_sonntag_zeitfenster_1": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Sonntag > Zeitfenster 1",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1106",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_sonntag_zeitfenster_2": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Sonntag > Zeitfenster 2",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1107",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_sonntag_zeitfenster_3": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Sonntag > Zeitfenster 3",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1108",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_temperatur": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Temperatur",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1110",
+        "valid_values": null,
+        "value": 55.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_registerleistung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Registerleistung",
+        "unit": "kW",
+        "url": "/120/10111/0/0/13150",
+        "valid_values": null,
+        "value": 7.7
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_solltemperatur_f\u00fcr_'sofort_laden'": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Solltemperatur f\u00fcr 'Sofort laden'",
+        "unit": "\u00b0C",
+        "url": "/120/10111/0/0/14257",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 50.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_temperaturwarnung_1_dauer_bis_warnung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Temperaturwarnung 1 > Dauer bis Warnung",
+        "unit": "s",
+        "url": "/120/10111/0/0/13166",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_temperaturwarnung_1_differenz_warnung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Temperaturwarnung 1 > Differenz Warnung",
+        "unit": "\u00b0C",
+        "url": "/120/10111/0/0/13039",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 80.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_warmwasserspeicher": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Warmwasserspeicher",
+        "unit": "\u00b0C",
+        "url": "/120/10111/0/0/12271",
+        "valid_values": null,
+        "value": 57.3
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_warmwasserspeicher_max.": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Warmwasserspeicher max.",
+        "unit": "\u00b0C",
+        "url": "/120/10111/0/0/12169",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 75.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_warmwasserspeicher_soll": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Warmwasserspeicher Soll",
+        "unit": "\u00b0C",
+        "url": "/120/10111/0/0/12132",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 55.0
+      }
+    },
+    "SWITCHES_DICT": {
+      "eta_192_168_0_25__fbh_heizkreis_estrich_start_estrich_ausheizen": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Heizkreis > Estrich > Start Estrich ausheizen",
+        "unit": "",
+        "url": "/120/10102/0/0/12303",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__fbh_heizkreis_solar_absch\u00f6pfen": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Heizkreis > Solar absch\u00f6pfen",
+        "unit": "",
+        "url": "/120/10102/0/0/12652",
+        "valid_values": {
+          "off_value": 1800,
+          "on_value": 1801
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__fbh_heizkreis_vorrang_warmwasser": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Heizkreis > Vorrang Warmwasser",
+        "unit": "",
+        "url": "/120/10102/0/0/12178",
+        "valid_values": {
+          "off_value": 1800,
+          "on_value": 1801
+        },
+        "value": "Ja"
+      },
+      "eta_192_168_0_25__fbh_sonstiges_absenken_taste": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Sonstiges > Absenken Taste",
+        "unit": "",
+        "url": "/120/10102/0/0/12230",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__fbh_sonstiges_auto_taste": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Sonstiges > Auto Taste",
+        "unit": "",
+        "url": "/120/10102/0/0/12126",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__fbh_sonstiges_ein/aus_taste": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Sonstiges > Ein/Aus Taste",
+        "unit": "",
+        "url": "/120/10102/0/0/12080",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__fbh_sonstiges_gehen_taste": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Sonstiges > Gehen Taste",
+        "unit": "",
+        "url": "/120/10102/0/0/12231",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__fbh_sonstiges_heizen_taste": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Sonstiges > Heizen Taste",
+        "unit": "",
+        "url": "/120/10102/0/0/12125",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__fbh_sonstiges_kommen_taste": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Sonstiges > Kommen Taste",
+        "unit": "",
+        "url": "/120/10102/0/0/12218",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__hk_heizkreis_estrich_start_estrich_ausheizen": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "HK > Heizkreis > Estrich > Start Estrich ausheizen",
+        "unit": "",
+        "url": "/120/10101/0/0/12303",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__hk_heizkreis_solar_absch\u00f6pfen": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "HK > Heizkreis > Solar absch\u00f6pfen",
+        "unit": "",
+        "url": "/120/10101/0/0/12652",
+        "valid_values": {
+          "off_value": 1800,
+          "on_value": 1801
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__hk_heizkreis_vorrang_warmwasser": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "HK > Heizkreis > Vorrang Warmwasser",
+        "unit": "",
+        "url": "/120/10101/0/0/12178",
+        "valid_values": {
+          "off_value": 1800,
+          "on_value": 1801
+        },
+        "value": "Ja"
+      },
+      "eta_192_168_0_25__hk_sonstiges_absenken_taste": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "HK > Sonstiges > Absenken Taste",
+        "unit": "",
+        "url": "/120/10101/0/0/12230",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__hk_sonstiges_auto_taste": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "HK > Sonstiges > Auto Taste",
+        "unit": "",
+        "url": "/120/10101/0/0/12126",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__hk_sonstiges_ein/aus_taste": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "HK > Sonstiges > Ein/Aus Taste",
+        "unit": "",
+        "url": "/120/10101/0/0/12080",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__hk_sonstiges_gehen_taste": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "HK > Sonstiges > Gehen Taste",
+        "unit": "",
+        "url": "/120/10101/0/0/12231",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__hk_sonstiges_heizen_taste": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "HK > Sonstiges > Heizen Taste",
+        "unit": "",
+        "url": "/120/10101/0/0/12125",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__hk_sonstiges_kommen_taste": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "HK > Sonstiges > Kommen Taste",
+        "unit": "",
+        "url": "/120/10101/0/0/12218",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_abgasgebl\u00e4se_abgasgebl\u00e4se_notbetrieb": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Abgasgebl\u00e4se > Abgasgebl\u00e4se > Notbetrieb",
+        "unit": "",
+        "url": "/40/10021/0/11120/2400",
+        "valid_values": {
+          "off_value": 1070,
+          "on_value": 1071
+        },
+        "value": "Nein"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kesseldruck_kesseldruck_notbetrieb": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kesseldruck > Kesseldruck > Notbetrieb",
+        "unit": "",
+        "url": "/40/10021/0/11135/2400",
+        "valid_values": {
+          "off_value": 1070,
+          "on_value": 1071
+        },
+        "value": "Nein"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_messblende_messblende_notbetrieb": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Messblende > Messblende > Notbetrieb",
+        "unit": "",
+        "url": "/40/10021/0/11134/2400",
+        "valid_values": {
+          "off_value": 1070,
+          "on_value": 1071
+        },
+        "value": "Nein"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_restsauerstoff_kalibrierung_extra_kalibrieren": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Restsauerstoff > Kalibrierung > Extra Kalibrieren",
+        "unit": "",
+        "url": "/40/10021/0/0/12301",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_restsauerstoff_kalibrierung_kalibrierung_abbrechen": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Restsauerstoff > Kalibrierung > Kalibrierung abbrechen",
+        "unit": "",
+        "url": "/40/10021/0/0/13943",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_restsauerstoff_notbetrieb": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Restsauerstoff > Notbetrieb",
+        "unit": "",
+        "url": "/40/10021/0/11108/2400",
+        "valid_values": {
+          "off_value": 1070,
+          "on_value": 1071
+        },
+        "value": "Nein"
+      },
+      "eta_192_168_0_25__kessel_kessel_abgas_emissionsmessung_messung_deaktivieren": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel > Abgas > Emissionsmessung > Messung deaktivieren",
+        "unit": "",
+        "url": "/40/10021/0/0/13277",
+        "valid_values": {
+          "off_value": 1800,
+          "on_value": 1801
+        },
+        "value": "Nein"
+      },
+      "eta_192_168_0_25__kessel_kessel_einstellungen_brenner_verriegeln": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel > Einstellungen > Brenner verriegeln",
+        "unit": "",
+        "url": "/40/10021/0/0/12651",
+        "valid_values": {
+          "off_value": 1800,
+          "on_value": 1801
+        },
+        "value": "Nein"
+      },
+      "eta_192_168_0_25__kessel_kessel_entaschung_glutabbrand_sofort_beenden": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel > Entaschung > Glutabbrand sofort beenden",
+        "unit": "",
+        "url": "/40/10021/0/0/13951",
+        "valid_values": {
+          "off_value": 1800,
+          "on_value": 1801
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__kessel_kessel_pelletsbeh\u00e4lter_pelletsbeh\u00e4lter_auff\u00fcllen": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel > Pelletsbeh\u00e4lter > Pelletsbeh\u00e4lter auff\u00fcllen",
+        "unit": "",
+        "url": "/40/10021/0/0/12071",
+        "valid_values": {
+          "off_value": 1800,
+          "on_value": 1801
+        },
+        "value": "Nein"
+      },
+      "eta_192_168_0_25__kessel_kessel_restsauerstoff_o2_soll_extrapol": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel > Restsauerstoff > O2 Soll > Extrapol",
+        "unit": "",
+        "url": "/40/10021/12004/0/1056",
+        "valid_values": {
+          "off_value": 1800,
+          "on_value": 1801
+        },
+        "value": "Nein"
+      },
+      "eta_192_168_0_25__kessel_sonstiges_ein/aus_taste": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Sonstiges > Ein/Aus Taste",
+        "unit": "",
+        "url": "/40/10021/0/0/12080",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__kessel_sonstiges_entaschentaste": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Sonstiges > Entaschentaste",
+        "unit": "",
+        "url": "/40/10021/0/0/12112",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__kessel_z\u00e4hlerst\u00e4nde_verbrauch_seit_wartung_z\u00e4hler_r\u00fccksetzen_?": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Z\u00e4hlerst\u00e4nde > Verbrauch seit Wartung > Z\u00e4hler r\u00fccksetzen ?",
+        "unit": "",
+        "url": "/40/10021/0/0/12257",
+        "valid_values": {
+          "off_value": 1800,
+          "on_value": 1801
+        },
+        "value": "Nein"
+      },
+      "eta_192_168_0_25__lagerum._sonstiges_taste_vor": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "LagerUm. > Sonstiges > Taste Vor",
+        "unit": "",
+        "url": "/40/10211/0/0/12883",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__lagerum._sonstiges_taste_zur\u00fcck": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "LagerUm. > Sonstiges > Taste Zur\u00fcck",
+        "unit": "",
+        "url": "/40/10211/0/0/12884",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__sys_externe_st\u00f6rmeldung_anzeigen": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Sys > Externe St\u00f6rmeldung > Anzeigen",
+        "unit": "",
+        "url": "/120/10241/0/0/14871",
+        "valid_values": {
+          "off_value": 1800,
+          "on_value": 1801
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__sys_st\u00f6rmeldung_anzeigen": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Sys > St\u00f6rmeldung > Anzeigen",
+        "unit": "",
+        "url": "/120/10241/0/0/14870",
+        "valid_values": {
+          "off_value": 1800,
+          "on_value": 1801
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__ww_sonstiges_ein/aus_taste": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "WW > Sonstiges > Ein/Aus Taste",
+        "unit": "",
+        "url": "/120/10111/0/0/12080",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__ww_sonstiges_warmwasser_sofort_laden": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "WW > Sonstiges > Warmwasser sofort laden",
+        "unit": "",
+        "url": "/120/10111/0/0/12134",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_laden_mit_anderen_verbrauchern": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "WW > Warmwasserspeicher > Laden mit anderen Verbrauchern",
+        "unit": "",
+        "url": "/120/10111/0/0/12667",
+        "valid_values": {
+          "off_value": 1800,
+          "on_value": 1801
+        },
+        "value": "Nein"
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_solar_absch\u00f6pfen": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "WW > Warmwasserspeicher > Solar absch\u00f6pfen",
+        "unit": "",
+        "url": "/120/10111/0/0/12652",
+        "valid_values": {
+          "off_value": 1800,
+          "on_value": 1801
+        },
+        "value": "xxx"
+      }
+    },
+    "TEXT_DICT": {
+      "eta_192_168_0_25__fbh_ausg\u00e4nge_heizkreismischer_anforderung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Ausg\u00e4nge > Heizkreismischer > Anforderung",
+        "unit": "",
+        "url": "/120/10102/0/11125/2001",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__fbh_ausg\u00e4nge_heizkreismischer_zustand": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Ausg\u00e4nge > Heizkreismischer > Zustand",
+        "unit": "",
+        "url": "/120/10102/0/11125/2002",
+        "valid_values": null,
+        "value": "Halt"
+      },
+      "eta_192_168_0_25__fbh_ausg\u00e4nge_pumpe_anforderung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Ausg\u00e4nge > Pumpe > Anforderung",
+        "unit": "",
+        "url": "/120/10102/0/11687/2001",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__fbh_ausg\u00e4nge_pumpe_drehzahlsteuerung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Ausg\u00e4nge > Pumpe > Drehzahlsteuerung",
+        "unit": "",
+        "url": "/120/10102/0/11687/2133",
+        "valid_values": null,
+        "value": "Heizungspumpe (siehe Infotaste!)"
+      },
+      "eta_192_168_0_25__fbh_ausg\u00e4nge_pumpe_zustand": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Ausg\u00e4nge > Pumpe > Zustand",
+        "unit": "",
+        "url": "/120/10102/0/11687/2002",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__fbh_eing\u00e4nge_vorlauf_sensor_typ": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Eing\u00e4nge > Vorlauf > Sensor Typ",
+        "unit": "",
+        "url": "/120/10102/0/11060/2011",
+        "valid_values": {
+          "Analoger Raumf\u00fchler": 1116,
+          "KTY": 1114,
+          "KTY Au\u00dfenf\u00fchler": 1115,
+          "Pt1000": 1111,
+          "Pt1000 Abgasf\u00fchler": 1112,
+          "Pt1000 Au\u00dfenf\u00fchler": 1113
+        },
+        "value": "Pt1000"
+      },
+      "eta_192_168_0_25__fbh_eing\u00e4nge_vorlauf_zustand": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Eing\u00e4nge > Vorlauf > Zustand",
+        "unit": "",
+        "url": "/120/10102/0/11060/2002",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__fbh_heizkreis": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Heizkreis",
+        "unit": "",
+        "url": "/120/10102/0/0/19404",
+        "valid_values": null,
+        "value": "Heizen"
+      },
+      "eta_192_168_0_25__fbh_heizkreis_erg\u00e4nzung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Heizkreis > Erg\u00e4nzung",
+        "unit": "",
+        "url": "/120/10102/0/0/19391",
+        "valid_values": null,
+        "value": "0_4067"
+      },
+      "eta_192_168_0_25__fbh_heizkreis_estrich": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Heizkreis > Estrich",
+        "unit": "",
+        "url": "/120/10102/0/0/12302",
+        "valid_values": null,
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__fbh_heizkreis_estrich_am_ende": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Heizkreis > Estrich > am Ende",
+        "unit": "",
+        "url": "/120/10102/0/0/14686",
+        "valid_values": {
+          "Absenkbetrieb": 6612,
+          "Automatikbetrieb": 6611,
+          "ausschalten": 6610
+        },
+        "value": "Automatikbetrieb"
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizkreispumpe": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Heizkreis > Heizkreispumpe",
+        "unit": "",
+        "url": "/120/10102/0/0/13922",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizkurve_bei_niedriger_heizkurve": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Heizkreis > Heizkurve > bei niedriger Heizkurve",
+        "unit": "",
+        "url": "/120/10102/0/0/14052",
+        "valid_values": {
+          "Abschalten": 6080,
+          "Vorlauf Min halten": 6081
+        },
+        "value": "Abschalten"
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizzeiten": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Heizkreis > Heizzeiten",
+        "unit": "",
+        "url": "/120/10102/12113/0/0",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizzeiten_schaltzustand": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Heizkreis > Heizzeiten > Schaltzustand",
+        "unit": "",
+        "url": "/120/10102/12113/0/1109",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__fbh_heizkreistyp": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Heizkreistyp",
+        "unit": "",
+        "url": "/120/10102/0/0/12476",
+        "valid_values": {
+          "Allgemein": 1808,
+          "Fussbodenheizung": 1806,
+          "Radiatorenheizung": 1807
+        },
+        "value": "Fussbodenheizung"
+      },
+      "eta_192_168_0_25__fbh_sonstiges_heizkreis": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Sonstiges > Heizkreis",
+        "unit": "",
+        "url": "/120/10102/0/0/12090",
+        "valid_values": null,
+        "value": "Ein Heizen"
+      },
+      "eta_192_168_0_25__hk_heizkreis": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "HK > Heizkreis",
+        "unit": "",
+        "url": "/120/10101/0/0/19404",
+        "valid_values": null,
+        "value": "Ausgeschaltet"
+      },
+      "eta_192_168_0_25__hk_heizkreis_erg\u00e4nzung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "HK > Heizkreis > Erg\u00e4nzung",
+        "unit": "",
+        "url": "/120/10101/0/0/19391",
+        "valid_values": null,
+        "value": "0_4067"
+      },
+      "eta_192_168_0_25__hk_heizkreis_estrich": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "HK > Heizkreis > Estrich",
+        "unit": "",
+        "url": "/120/10101/0/0/12302",
+        "valid_values": null,
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__hk_heizkreis_estrich_am_ende": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "HK > Heizkreis > Estrich > am Ende",
+        "unit": "",
+        "url": "/120/10101/0/0/14686",
+        "valid_values": {
+          "Absenkbetrieb": 6612,
+          "Automatikbetrieb": 6611,
+          "ausschalten": 6610
+        },
+        "value": "Automatikbetrieb"
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizkurve_bei_niedriger_heizkurve": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "HK > Heizkreis > Heizkurve > bei niedriger Heizkurve",
+        "unit": "",
+        "url": "/120/10101/0/0/14052",
+        "valid_values": {
+          "Abschalten": 6080,
+          "Vorlauf Min halten": 6081
+        },
+        "value": "Abschalten"
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizzeiten": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "HK > Heizkreis > Heizzeiten",
+        "unit": "",
+        "url": "/120/10101/12113/0/0",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizzeiten_schaltzustand": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "HK > Heizkreis > Heizzeiten > Schaltzustand",
+        "unit": "",
+        "url": "/120/10101/12113/0/1109",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__hk_heizkreistyp": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "HK > Heizkreistyp",
+        "unit": "",
+        "url": "/120/10101/0/0/12476",
+        "valid_values": {
+          "Allgemein": 1808,
+          "Fussbodenheizung": 1806,
+          "Radiatorenheizung": 1807
+        },
+        "value": "Allgemein"
+      },
+      "eta_192_168_0_25__hk_sonstiges_heizkreis": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "HK > Sonstiges > Heizkreis",
+        "unit": "",
+        "url": "/120/10101/0/0/12090",
+        "valid_values": null,
+        "value": "Aus Sommer"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_abgasgebl\u00e4se_abgasgebl\u00e4se": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Abgasgebl\u00e4se > Abgasgebl\u00e4se",
+        "unit": "",
+        "url": "/40/10021/0/11120/0",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_abgasgebl\u00e4se_abgasgebl\u00e4se_anforderung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Abgasgebl\u00e4se > Abgasgebl\u00e4se > Anforderung",
+        "unit": "",
+        "url": "/40/10021/0/11120/2001",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_abgasgebl\u00e4se_abgasgebl\u00e4se_drehzahlsteuerung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Abgasgebl\u00e4se > Abgasgebl\u00e4se > Drehzahlsteuerung",
+        "unit": "",
+        "url": "/40/10021/0/11120/2133",
+        "valid_values": {
+          "Phasenanschnitt": 1270,
+          "Pulspaket": 1271
+        },
+        "value": "Phasenanschnitt"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_abgasgebl\u00e4se_abgasgebl\u00e4se_zustand": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Abgasgebl\u00e4se > Abgasgebl\u00e4se > Zustand",
+        "unit": "",
+        "url": "/40/10021/0/11120/2002",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_entaschung_und_rost": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Entaschung und Rost",
+        "unit": "",
+        "url": "/40/10021/0/11048/0",
+        "valid_values": null,
+        "value": "Halt"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_entaschung_und_rost_anforderung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Entaschung und Rost > Anforderung",
+        "unit": "",
+        "url": "/40/10021/0/11048/2001",
+        "valid_values": null,
+        "value": "Halt"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_entaschung_und_rost_schalter": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Entaschung und Rost > Schalter",
+        "unit": "",
+        "url": "/40/10021/0/11048/2083",
+        "valid_values": null,
+        "value": "Ja"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_entaschung_und_rost_zustand": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Entaschung und Rost > Zustand",
+        "unit": "",
+        "url": "/40/10021/0/11048/2002",
+        "valid_values": null,
+        "value": "Halt"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_kesselpumpe_anforderung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Kesselpumpe > Anforderung",
+        "unit": "",
+        "url": "/40/10021/0/11123/2001",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_kesselpumpe_drehzahlsteuerung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Kesselpumpe > Drehzahlsteuerung",
+        "unit": "",
+        "url": "/40/10021/0/11123/2133",
+        "valid_values": {
+          "0-10V analog": 1285,
+          "Ein/Aus": 1280,
+          "Heizungspumpe (siehe Infotaste!)": 1283,
+          "Laing/Lowara Kesselpumpe f\u00fcr PU/PC": 1282,
+          "Pulspaket f\u00fcr NICHT elektronisch geregelte Pumpe": 1281,
+          "Solarpumpe (siehe Infotaste!)": 1284
+        },
+        "value": "Heizungspumpe (siehe Infotaste!)"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_kesselpumpe_zustand": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Kesselpumpe > Zustand",
+        "unit": "",
+        "url": "/40/10021/0/11123/2002",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_luftschieber_anforderung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Luftschieber > Anforderung",
+        "unit": "",
+        "url": "/40/10021/0/11115/2001",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_luftschieber_schlie\u00dft_nach": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Luftschieber > Schlie\u00dft nach",
+        "unit": "",
+        "url": "/40/10021/0/11115/2417",
+        "valid_values": null,
+        "value": "Links"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_luftschieber_zustand": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Luftschieber > Zustand",
+        "unit": "",
+        "url": "/40/10021/0/11115/2002",
+        "valid_values": null,
+        "value": "Fehler"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_saugturbine": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Saugturbine",
+        "unit": "",
+        "url": "/40/10021/0/11042/0",
+        "valid_values": null,
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_saugturbine_anforderung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Saugturbine > Anforderung",
+        "unit": "",
+        "url": "/40/10021/0/11042/2001",
+        "valid_values": null,
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_stokerschnecke_anforderung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Stokerschnecke > Anforderung",
+        "unit": "",
+        "url": "/40/10021/0/11030/2001",
+        "valid_values": null,
+        "value": "Vor"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_stokerschnecke_zustand": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Stokerschnecke > Zustand",
+        "unit": "",
+        "url": "/40/10021/0/11030/2002",
+        "valid_values": null,
+        "value": "Vor"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_umschaltventil": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Umschaltventil",
+        "unit": "",
+        "url": "/40/10021/0/11128/0",
+        "valid_values": null,
+        "value": "Halt"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_umschaltventil_anforderung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Umschaltventil > Anforderung",
+        "unit": "",
+        "url": "/40/10021/0/11128/2001",
+        "valid_values": null,
+        "value": "Halt"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_vorlaufmischer_1_anforderung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Vorlaufmischer 1 > Anforderung",
+        "unit": "",
+        "url": "/40/10021/0/11121/2001",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_vorlaufmischer_1_zustand": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Vorlaufmischer 1 > Zustand",
+        "unit": "",
+        "url": "/40/10021/0/11121/2002",
+        "valid_values": null,
+        "value": "Halt"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_z\u00fcndung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Z\u00fcndung",
+        "unit": "",
+        "url": "/40/10021/0/11041/0",
+        "valid_values": null,
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_z\u00fcndung_anforderung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Z\u00fcndung > Anforderung",
+        "unit": "",
+        "url": "/40/10021/0/11041/2001",
+        "valid_values": null,
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_abgas_sensor_typ": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Abgas > Sensor Typ",
+        "unit": "",
+        "url": "/40/10021/0/11110/2011",
+        "valid_values": {
+          "Analoger Raumf\u00fchler": 1116,
+          "KTY": 1114,
+          "KTY Au\u00dfenf\u00fchler": 1115,
+          "Pt1000": 1111,
+          "Pt1000 Abgasf\u00fchler": 1112,
+          "Pt1000 Au\u00dfenf\u00fchler": 1113
+        },
+        "value": "Pt1000 Abgasf\u00fchler"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_abgas_zustand": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Abgas > Zustand",
+        "unit": "",
+        "url": "/40/10021/0/11110/2002",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_aschebox": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Aschebox",
+        "unit": "",
+        "url": "/40/10021/0/11034/0",
+        "valid_values": null,
+        "value": "Ja"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_aschebox_eingang": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Aschebox > Eingang",
+        "unit": "",
+        "url": "/40/10021/0/11034/2017",
+        "valid_values": {
+          "Invertiert": 3451,
+          "Nicht invertiert": 3450
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_glutbett": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Glutbett",
+        "unit": "",
+        "url": "/40/10021/0/11036/0",
+        "valid_values": null,
+        "value": "OK"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_glutbett_eingang": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Glutbett > Eingang",
+        "unit": "",
+        "url": "/40/10021/0/11036/2017",
+        "valid_values": {
+          "Invertiert": 3451,
+          "Nicht invertiert": 3450
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel_sensor_typ": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel > Sensor Typ",
+        "unit": "",
+        "url": "/40/10021/0/11109/2011",
+        "valid_values": {
+          "Analoger Raumf\u00fchler": 1116,
+          "KTY": 1114,
+          "KTY Au\u00dfenf\u00fchler": 1115,
+          "Pt1000": 1111,
+          "Pt1000 Abgasf\u00fchler": 1112,
+          "Pt1000 Au\u00dfenf\u00fchler": 1113
+        },
+        "value": "Pt1000"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel_unten_sensor_typ": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel unten > Sensor Typ",
+        "unit": "",
+        "url": "/40/10021/0/11122/2011",
+        "valid_values": {
+          "Analoger Raumf\u00fchler": 1116,
+          "KTY": 1114,
+          "KTY Au\u00dfenf\u00fchler": 1115,
+          "Pt1000": 1111,
+          "Pt1000 Abgasf\u00fchler": 1112,
+          "Pt1000 Au\u00dfenf\u00fchler": 1113
+        },
+        "value": "Pt1000"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel_unten_zustand": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel unten > Zustand",
+        "unit": "",
+        "url": "/40/10021/0/11122/2002",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel_vorlauf_1_sensor_typ": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel Vorlauf 1 > Sensor Typ",
+        "unit": "",
+        "url": "/40/10021/0/11058/2011",
+        "valid_values": {
+          "Analoger Raumf\u00fchler": 1116,
+          "KTY": 1114,
+          "KTY Au\u00dfenf\u00fchler": 1115,
+          "Pt1000": 1111,
+          "Pt1000 Abgasf\u00fchler": 1112,
+          "Pt1000 Au\u00dfenf\u00fchler": 1113
+        },
+        "value": "Pt1000"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel_vorlauf_1_zustand": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel Vorlauf 1 > Zustand",
+        "unit": "",
+        "url": "/40/10021/0/11058/2002",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_messblende_versorgung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Messblende > Versorgung",
+        "unit": "",
+        "url": "/40/10021/0/11181/0",
+        "valid_values": null,
+        "value": "Vor"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_messblende_versorgung_anforderung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Messblende > Versorgung > Anforderung",
+        "unit": "",
+        "url": "/40/10021/0/11181/2001",
+        "valid_values": null,
+        "value": "Vor"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_not-aus_schalter": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Not-Aus Schalter",
+        "unit": "",
+        "url": "/40/10021/0/11032/0",
+        "valid_values": null,
+        "value": "OK"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_not-aus_schalter_eingang": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Not-Aus Schalter > Eingang",
+        "unit": "",
+        "url": "/40/10021/0/11032/2017",
+        "valid_values": {
+          "Invertiert": 3451,
+          "Nicht invertiert": 3450
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_pelletsbeh\u00e4lter": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Pelletsbeh\u00e4lter",
+        "unit": "",
+        "url": "/40/10021/0/11037/0",
+        "valid_values": null,
+        "value": "Nicht voll"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_pelletsbeh\u00e4lter_eingang": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Pelletsbeh\u00e4lter > Eingang",
+        "unit": "",
+        "url": "/40/10021/0/11037/2017",
+        "valid_values": {
+          "Invertiert": 3451,
+          "Nicht invertiert": 3450
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_restsauerstoff_anforderung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Restsauerstoff > Anforderung",
+        "unit": "",
+        "url": "/40/10021/0/11108/2001",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_restsauerstoff_kalibrierung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Restsauerstoff > Kalibrierung",
+        "unit": "",
+        "url": "/40/10021/0/0/13944",
+        "valid_values": null,
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_restsauerstoff_sensor_typ": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Restsauerstoff > Sensor Typ",
+        "unit": "",
+        "url": "/40/10021/0/11108/2011",
+        "valid_values": {
+          "HuS 118": 1122,
+          "LSU4": 1121,
+          "NGK ZFAS": 1123
+        },
+        "value": "HuS 118"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_restsauerstoff_zustand": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Restsauerstoff > Zustand",
+        "unit": "",
+        "url": "/40/10021/0/11108/2002",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_rost_geschlossen?": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Rost geschlossen?",
+        "unit": "",
+        "url": "/40/10021/0/0/12251",
+        "valid_values": null,
+        "value": "Ja"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_stb": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > STB",
+        "unit": "",
+        "url": "/40/10021/0/11033/0",
+        "valid_values": null,
+        "value": "OK"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_stb_eingang": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > STB > Eingang",
+        "unit": "",
+        "url": "/40/10021/0/11033/2017",
+        "valid_values": {
+          "Invertiert": 3451,
+          "Nicht invertiert": 3450
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_wassermangel": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Wassermangel",
+        "unit": "",
+        "url": "/40/10021/0/11031/0",
+        "valid_values": null,
+        "value": "OK"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_wassermangel_eingang": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Wassermangel > Eingang",
+        "unit": "",
+        "url": "/40/10021/0/11031/2017",
+        "valid_values": {
+          "Invertiert": 3451,
+          "Nicht invertiert": 3450
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__kessel_kessel": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel",
+        "unit": "",
+        "url": "/40/10021/0/0/19402",
+        "valid_values": null,
+        "value": "Heizen"
+      },
+      "eta_192_168_0_25__kessel_kessel_abgas_emissionsmessung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel > Abgas > Emissionsmessung",
+        "unit": "",
+        "url": "/40/10021/0/0/13266",
+        "valid_values": null,
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__kessel_kessel_abgas_emissionsmessung_art_der_messung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel > Abgas > Emissionsmessung > Art der Messung",
+        "unit": "",
+        "url": "/40/10021/0/0/12116",
+        "valid_values": {
+          "Kombination": 1962,
+          "Nennlast": 1960,
+          "Teillast": 1961
+        },
+        "value": "Nennlast"
+      },
+      "eta_192_168_0_25__kessel_kessel_abgas_emissionsmessung_jetzt_starten": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel > Abgas > Emissionsmessung > Jetzt starten",
+        "unit": "",
+        "url": "/40/10021/0/0/13269",
+        "valid_values": {
+          "Ja, gleich Messen": 3932,
+          "Ja, zuerst Entaschen": 3931,
+          "Nein": 3930
+        },
+        "value": "Nein"
+      },
+      "eta_192_168_0_25__kessel_kessel_entaschung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel > Entaschung",
+        "unit": "",
+        "url": "/40/10021/0/0/12050",
+        "valid_values": null,
+        "value": "Bereit"
+      },
+      "eta_192_168_0_25__kessel_kessel_erg\u00e4nzung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel > Erg\u00e4nzung",
+        "unit": "",
+        "url": "/40/10021/0/0/19391",
+        "valid_values": null,
+        "value": "0_4200"
+      },
+      "eta_192_168_0_25__kessel_kessel_kessellaufmeldung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel > Kessellaufmeldung",
+        "unit": "",
+        "url": "/40/10021/0/0/14268",
+        "valid_values": null,
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__kessel_kessel_kessellaufmeldung_aktiv_wenn": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel > Kessellaufmeldung > Aktiv wenn",
+        "unit": "",
+        "url": "/40/10021/0/0/13161",
+        "valid_values": {
+          "Abgasgebl\u00e4se ein": 3000,
+          "Brennstofff\u00f6rderung ein": 3001,
+          "Ein/Aus Taste ein": 3002,
+          "Kesselzustand ist Heizen": 3003
+        },
+        "value": "Abgasgebl\u00e4se ein"
+      },
+      "eta_192_168_0_25__kessel_kessel_kessellaufmeldung_laufmeldung_von_schnittstellen": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel > Kessellaufmeldung > Laufmeldung von Schnittstellen",
+        "unit": "",
+        "url": "/40/10021/0/0/14275",
+        "valid_values": null,
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__kessel_kessel_kesselst\u00f6rmeldung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel > Kesselst\u00f6rmeldung",
+        "unit": "",
+        "url": "/40/10021/0/0/14265",
+        "valid_values": null,
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__kessel_kessel_kesselst\u00f6rmeldung_ab_priorit\u00e4t": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel > Kesselst\u00f6rmeldung > ab Priorit\u00e4t",
+        "unit": "",
+        "url": "/40/10021/0/0/13353",
+        "valid_values": {
+          "Fehler": 3252,
+          "Meldung": 3250,
+          "Warnung": 3251
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__kessel_kessel_kesselst\u00f6rmeldung_kesselst\u00f6rmeldung_f\u00fcr_schnittstellen": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel > Kesselst\u00f6rmeldung > Kesselst\u00f6rmeldung f\u00fcr Schnittstellen",
+        "unit": "",
+        "url": "/40/10021/0/0/14267",
+        "valid_values": null,
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__kessel_kessel_pelletsbeh\u00e4lter": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel > Pelletsbeh\u00e4lter",
+        "unit": "",
+        "url": "/40/10021/0/0/12005",
+        "valid_values": null,
+        "value": "Nicht voll"
+      },
+      "eta_192_168_0_25__kessel_kessel_vorlaufregler_1": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel > Vorlaufregler 1",
+        "unit": "",
+        "url": "/40/10021/0/0/12078",
+        "valid_values": null,
+        "value": "Regeln"
+      },
+      "eta_192_168_0_25__kessel_kessel_z\u00fcndung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel > Z\u00fcndung",
+        "unit": "",
+        "url": "/40/10021/0/0/12163",
+        "valid_values": null,
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__kessel_sonstiges_designvariante": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Sonstiges > Designvariante",
+        "unit": "",
+        "url": "/40/10021/0/0/13603",
+        "valid_values": null,
+        "value": "ab 2016"
+      },
+      "eta_192_168_0_25__kessel_sonstiges_kessel": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Sonstiges > Kessel",
+        "unit": "",
+        "url": "/40/10021/0/0/12000",
+        "valid_values": null,
+        "value": "Heizen"
+      },
+      "eta_192_168_0_25__lagerum._ausg\u00e4nge_umschalteinheit": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "LagerUm. > Ausg\u00e4nge > Umschalteinheit",
+        "unit": "",
+        "url": "/40/10211/0/11132/0",
+        "valid_values": null,
+        "value": "Halt"
+      },
+      "eta_192_168_0_25__lagerum._ausg\u00e4nge_umschalteinheit_anforderung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "LagerUm. > Ausg\u00e4nge > Umschalteinheit > Anforderung",
+        "unit": "",
+        "url": "/40/10211/0/11132/2001",
+        "valid_values": null,
+        "value": "Halt"
+      },
+      "eta_192_168_0_25__lagerum._ausg\u00e4nge_umschalteinheit_zustand": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "LagerUm. > Ausg\u00e4nge > Umschalteinheit > Zustand",
+        "unit": "",
+        "url": "/40/10211/0/11132/2002",
+        "valid_values": null,
+        "value": "Halt"
+      },
+      "eta_192_168_0_25__lagerum._eing\u00e4nge_nullpunktschalter": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "LagerUm. > Eing\u00e4nge > Nullpunktschalter",
+        "unit": "",
+        "url": "/40/10211/0/11133/0",
+        "valid_values": null,
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__lagerum._eing\u00e4nge_nullpunktschalter_eingang": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "LagerUm. > Eing\u00e4nge > Nullpunktschalter > Eingang",
+        "unit": "",
+        "url": "/40/10211/0/11133/2017",
+        "valid_values": {
+          "Invertiert": 3451,
+          "Nicht invertiert": 3450
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__lagerum._eing\u00e4nge_positionsschalter": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "LagerUm. > Eing\u00e4nge > Positionsschalter",
+        "unit": "",
+        "url": "/40/10211/0/0/12266",
+        "valid_values": null,
+        "value": "Ja"
+      },
+      "eta_192_168_0_25__lagerum._sonstiges_austragung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "LagerUm. > Sonstiges > Austragung",
+        "unit": "",
+        "url": "/40/10211/0/0/12058",
+        "valid_values": null,
+        "value": "Bereit"
+      },
+      "eta_192_168_0_25__lagerum._sonstiges_position_1": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "LagerUm. > Sonstiges > Position 1",
+        "unit": "",
+        "url": "/40/10211/0/0/12262",
+        "valid_values": {
+          "Frei": 1804,
+          "Gesperrt": 1805
+        },
+        "value": "Frei"
+      },
+      "eta_192_168_0_25__lagerum._sonstiges_position_2": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "LagerUm. > Sonstiges > Position 2",
+        "unit": "",
+        "url": "/40/10211/0/0/12263",
+        "valid_values": {
+          "Frei": 1804,
+          "Gesperrt": 1805
+        },
+        "value": "Frei"
+      },
+      "eta_192_168_0_25__lagerum._sonstiges_position_3": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "LagerUm. > Sonstiges > Position 3",
+        "unit": "",
+        "url": "/40/10211/0/0/12264",
+        "valid_values": {
+          "Frei": 1804,
+          "Gesperrt": 1805
+        },
+        "value": "Frei"
+      },
+      "eta_192_168_0_25__lagerum._sonstiges_position_4": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "LagerUm. > Sonstiges > Position 4",
+        "unit": "",
+        "url": "/40/10211/0/0/12539",
+        "valid_values": {
+          "Frei": 1804,
+          "Gesperrt": 1805
+        },
+        "value": "Frei"
+      },
+      "eta_192_168_0_25__lagerum._sonstiges_position_5": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "LagerUm. > Sonstiges > Position 5",
+        "unit": "",
+        "url": "/40/10211/0/0/12879",
+        "valid_values": {
+          "Frei": 1804,
+          "Gesperrt": 1805
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__lagerum._sonstiges_position_6": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "LagerUm. > Sonstiges > Position 6",
+        "unit": "",
+        "url": "/40/10211/0/0/12880",
+        "valid_values": {
+          "Frei": 1804,
+          "Gesperrt": 1805
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__lagerum._sonstiges_position_7": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "LagerUm. > Sonstiges > Position 7",
+        "unit": "",
+        "url": "/40/10211/0/0/12881",
+        "valid_values": {
+          "Frei": 1804,
+          "Gesperrt": 1805
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__lagerum._sonstiges_position_8": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "LagerUm. > Sonstiges > Position 8",
+        "unit": "",
+        "url": "/40/10211/0/0/12882",
+        "valid_values": {
+          "Frei": 1804,
+          "Gesperrt": 1805
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__lagerum._typ_der_umschalteinheit": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "LagerUm. > Typ der Umschalteinheit",
+        "unit": "",
+        "url": "/40/10211/0/0/13986",
+        "valid_values": {
+          "3-fach": 6001,
+          "4-fach": 6002,
+          "8-fach drehend": 6004,
+          "8-fach linear": 6003
+        },
+        "value": "4-fach"
+      },
+      "eta_192_168_0_25__sys_antiblockierschutz_an_welchem_tag?": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Sys > Antiblockierschutz > an welchem Tag?",
+        "unit": "",
+        "url": "/120/10241/0/0/14243",
+        "valid_values": {
+          "Dienstag": 6352,
+          "Donnerstag": 6354,
+          "Freitag": 6355,
+          "Mittwoch": 6353,
+          "Montag": 6351,
+          "Samstag": 6356,
+          "Sonntag": 6350
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__sys_antiblockierschutz_zeitpunkt": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Sys > Antiblockierschutz > Zeitpunkt",
+        "unit": "",
+        "url": "/120/10241/0/0/14242",
+        "valid_values": {
+          "einstellbar": 6361,
+          "fix": 6360
+        },
+        "value": "fix"
+      },
+      "eta_192_168_0_25__sys_au\u00dfentemperatur_au\u00dfentemperaturf\u00fchler_sensor_typ": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Sys > Au\u00dfentemperatur > Au\u00dfentemperaturf\u00fchler > Sensor Typ",
+        "unit": "",
+        "url": "/120/10241/0/11127/2011",
+        "valid_values": {
+          "Analoger Raumf\u00fchler": 1116,
+          "KTY": 1114,
+          "KTY Au\u00dfenf\u00fchler": 1115,
+          "Pt1000": 1111,
+          "Pt1000 Abgasf\u00fchler": 1112,
+          "Pt1000 Au\u00dfenf\u00fchler": 1113
+        },
+        "value": "Pt1000 Au\u00dfenf\u00fchler"
+      },
+      "eta_192_168_0_25__sys_au\u00dfentemperatur_au\u00dfentemperaturf\u00fchler_zustand": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Sys > Au\u00dfentemperatur > Au\u00dfentemperaturf\u00fchler > Zustand",
+        "unit": "",
+        "url": "/120/10241/0/11127/2002",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__sys_externe_st\u00f6rmeldung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Sys > Externe St\u00f6rmeldung",
+        "unit": "",
+        "url": "/120/10241/0/0/14259",
+        "valid_values": null,
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__sys_externe_st\u00f6rmeldung_externe_st\u00f6rmeldung_von_schnittstellen": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Sys > Externe St\u00f6rmeldung > Externe St\u00f6rmeldung von Schnittstellen",
+        "unit": "",
+        "url": "/120/10241/0/0/14261",
+        "valid_values": {
+          "Fehler": 1050,
+          "OK": 1051
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__sys_st\u00f6rmeldung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Sys > St\u00f6rmeldung",
+        "unit": "",
+        "url": "/120/10241/0/0/14262",
+        "valid_values": null,
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__sys_st\u00f6rmeldung_ab_priorit\u00e4t": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Sys > St\u00f6rmeldung > ab Priorit\u00e4t",
+        "unit": "",
+        "url": "/120/10241/0/0/13353",
+        "valid_values": {
+          "Alarm": 3253,
+          "Fehler": 3252,
+          "Meldung": 3250,
+          "Warnung": 3251
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__sys_st\u00f6rmeldung_st\u00f6rmeldung_f\u00fcr_schnittstellen": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Sys > St\u00f6rmeldung > St\u00f6rmeldung f\u00fcr Schnittstellen",
+        "unit": "",
+        "url": "/120/10241/0/0/14264",
+        "valid_values": null,
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__ww_eing\u00e4nge_warmwasserspeicher_sensor_typ": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "WW > Eing\u00e4nge > Warmwasserspeicher > Sensor Typ",
+        "unit": "",
+        "url": "/120/10111/0/11129/2011",
+        "valid_values": {
+          "Analoger Raumf\u00fchler": 1116,
+          "KTY": 1114,
+          "KTY Au\u00dfenf\u00fchler": 1115,
+          "Pt1000": 1111,
+          "Pt1000 Abgasf\u00fchler": 1112,
+          "Pt1000 Au\u00dfenf\u00fchler": 1113
+        },
+        "value": "Pt1000"
+      },
+      "eta_192_168_0_25__ww_eing\u00e4nge_warmwasserspeicher_zustand": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "WW > Eing\u00e4nge > Warmwasserspeicher > Zustand",
+        "unit": "",
+        "url": "/120/10111/0/11129/2002",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__ww_sonstiges_warmwasserspeicher": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "WW > Sonstiges > Warmwasserspeicher",
+        "unit": "",
+        "url": "/120/10111/0/0/12129",
+        "valid_values": null,
+        "value": "Geladen"
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "WW > Warmwasserspeicher",
+        "unit": "",
+        "url": "/120/10111/0/0/19406",
+        "valid_values": null,
+        "value": "Geladen"
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_erg\u00e4nzung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "WW > Warmwasserspeicher > Erg\u00e4nzung",
+        "unit": "",
+        "url": "/120/10111/0/0/19391",
+        "valid_values": null,
+        "value": "0_4080"
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_laden_mit_erzeuger": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "WW > Warmwasserspeicher > Laden mit Erzeuger",
+        "unit": "",
+        "url": "/120/10111/0/0/12932",
+        "valid_values": {
+          "Nein": 6530,
+          "mit jedem Erzeuger": 6531,
+          "nicht mit Brenner": 6533,
+          "nur mit St\u00fcckholzkessel": 6532
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten",
+        "unit": "",
+        "url": "/120/10111/12130/0/0",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_schaltzustand": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Schaltzustand",
+        "unit": "",
+        "url": "/120/10111/12130/0/1109",
+        "valid_values": null,
+        "value": "Ein"
+      }
+    },
+    "WRITABLE_DICT": {
+      "eta_192_168_0_25__fbh_eing\u00e4nge_vorlauf_fixwert_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Eing\u00e4nge > Vorlauf > Fixwert",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/11060/2054",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__fbh_eing\u00e4nge_vorlauf_kalibrierwert_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Eing\u00e4nge > Vorlauf > Kalibrierwert",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/11060/2049",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 5.0,
+          "scaled_min_value": -5.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_anforderungsdifferenz_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Anforderungsdifferenz",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12109",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 50.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 3.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_estrich_absenkung_um_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Estrich > Absenkung um",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12309",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 20.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 3.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_estrich_anstieg_um_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Estrich > Anstieg um",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12305",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 20.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 3.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_estrich_erneute_max._temperatur_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Estrich > erneute Max. Temperatur",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/14688",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 60.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_estrich_max._temperatur_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Estrich > Max. Temperatur",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12307",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 60.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 40.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_estrich_vorlauf_soll_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Estrich > Vorlauf Soll",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12304",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 60.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 15.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizgrenze_f\u00fcr_'absenken'_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizgrenze f\u00fcr 'Absenken'",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12097",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 50.0,
+          "scaled_min_value": -50.0
+        },
+        "value": 2.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizgrenze_f\u00fcr_'heizen'_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizgrenze f\u00fcr 'Heizen'",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/14116",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 50.0,
+          "scaled_min_value": -50.0
+        },
+        "value": 22.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizkreispumpe_pumpendrehzahl_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizkreispumpe > Pumpendrehzahl",
+        "unit": "%",
+        "url": "/120/10102/0/0/12258",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 10.0
+        },
+        "value": 60.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizkurve_aus_bei_heizkurve_unter_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizkurve > Aus bei Heizkurve unter",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/14133",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 50.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 22.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizkurve_schieber_position_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizkurve > Schieber Position",
+        "unit": "%",
+        "url": "/120/10102/0/0/12240",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": -100.0
+        },
+        "value": 50.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizkurve_vorlauf_absenkung_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizkurve > Vorlauf Absenkung",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12107",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 50.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 3.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizkurve_vorlauf_bei_+10\u00b0c_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizkurve > Vorlauf bei +10\u00b0C",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12103",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 25.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizkurve_vorlauf_bei_-10\u00b0c_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizkurve > Vorlauf bei -10\u00b0C",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12104",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 33.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_vorlauf_vorlauf_max_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Vorlauf > Vorlauf Max",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12108",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 45.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_estrich_absenkung_um_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Estrich > Absenkung um",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12309",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 20.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 3.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_estrich_anstieg_um_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Estrich > Anstieg um",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12305",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 20.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 3.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_estrich_erneute_max._temperatur_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Estrich > erneute Max. Temperatur",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/14688",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 60.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_estrich_max._temperatur_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Estrich > Max. Temperatur",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12307",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 60.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 40.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_estrich_vorlauf_soll_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Estrich > Vorlauf Soll",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12304",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 60.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 15.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizgrenze_f\u00fcr_'absenken'_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizgrenze f\u00fcr 'Absenken'",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12097",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 50.0,
+          "scaled_min_value": -50.0
+        },
+        "value": 2.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizgrenze_f\u00fcr_'heizen'_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizgrenze f\u00fcr 'Heizen'",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/14116",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 50.0,
+          "scaled_min_value": -50.0
+        },
+        "value": 21.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizkurve_aus_bei_heizkurve_unter_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizkurve > Aus bei Heizkurve unter",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/14133",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 50.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 22.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizkurve_schieber_position_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizkurve > Schieber Position",
+        "unit": "%",
+        "url": "/120/10101/0/0/12240",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": -100.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizkurve_vorlauf_absenkung_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizkurve > Vorlauf Absenkung",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12107",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 50.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 3.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizkurve_vorlauf_bei_+10\u00b0c_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizkurve > Vorlauf bei +10\u00b0C",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12103",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 25.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizkurve_vorlauf_bei_-10\u00b0c_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizkurve > Vorlauf bei -10\u00b0C",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12104",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 33.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_vorlauf_vorlauf_max_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Vorlauf > Vorlauf Max",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12108",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 45.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_abgas_fixwert_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Abgas > Fixwert",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11110/2054",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 200.0,
+          "scaled_min_value": -100.0
+        },
+        "value": 120.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_abgas_kalibrierwert_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Abgas > Kalibrierwert",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11110/2049",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 5.0,
+          "scaled_min_value": -5.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel_fixwert_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel > Fixwert",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11109/2054",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 200.0,
+          "scaled_min_value": -100.0
+        },
+        "value": 70.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel_kalibrierwert_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel > Kalibrierwert",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11109/2049",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 5.0,
+          "scaled_min_value": -5.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel_unten_fixwert_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel unten > Fixwert",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11122/2054",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 200.0,
+          "scaled_min_value": -100.0
+        },
+        "value": 55.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel_unten_kalibrierwert_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel unten > Kalibrierwert",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11122/2049",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 5.0,
+          "scaled_min_value": -5.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel_vorlauf_1_fixwert_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel Vorlauf 1 > Fixwert",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11058/2054",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 200.0,
+          "scaled_min_value": -100.0
+        },
+        "value": 60.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel_vorlauf_1_kalibrierwert_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel Vorlauf 1 > Kalibrierwert",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11058/2049",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 5.0,
+          "scaled_min_value": -5.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__kessel_kessel_abgas_abgas_max_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Abgas > Abgas Max",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/0/12023",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 300.0,
+          "scaled_min_value": 100.0
+        },
+        "value": 180.0
+      },
+      "eta_192_168_0_25__kessel_kessel_entaschung_aschebox_leeren_nach_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Entaschung > Aschebox leeren nach",
+        "unit": "kg",
+        "url": "/40/10021/0/0/12120",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 5000.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 1000.0
+      },
+      "eta_192_168_0_25__kessel_kessel_entaschung_beginn_ruhezeit_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Entaschung > Beginn Ruhezeit",
+        "unit": "minutes_since_midnight",
+        "url": "/40/10021/0/0/12248",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 1,
+          "scaled_max_value": 1439.0,
+          "scaled_min_value": 0.0
+        },
+        "value": "21:00"
+      },
+      "eta_192_168_0_25__kessel_kessel_entaschung_entaschen_nach_max._writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Entaschung > Entaschen nach max.",
+        "unit": "kg",
+        "url": "/40/10021/0/0/12074",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 25.0
+      },
+      "eta_192_168_0_25__kessel_kessel_entaschung_entaschen_nach_min._writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Entaschung > Entaschen nach min.",
+        "unit": "kg",
+        "url": "/40/10021/0/0/12073",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 15.0
+      },
+      "eta_192_168_0_25__kessel_kessel_kessel_ausschaltdifferenz_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Kessel > Ausschaltdifferenz",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/0/12141",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 40.0,
+          "scaled_min_value": 3.0
+        },
+        "value": 15.0
+      },
+      "eta_192_168_0_25__kessel_kessel_kessel_kessel_min_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Kessel > Kessel Min",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/0/12022",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 50.0
+        },
+        "value": 55.0
+      },
+      "eta_192_168_0_25__kessel_kessel_kesselpumpe_maximal_drehzahl_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Kesselpumpe > Maximal Drehzahl",
+        "unit": "%",
+        "url": "/40/10021/0/0/12368",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 10.0
+        },
+        "value": 100.0
+      },
+      "eta_192_168_0_25__kessel_kessel_kesselpumpe_mindest_drehzahl_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Kesselpumpe > Mindest Drehzahl",
+        "unit": "%",
+        "url": "/40/10021/0/0/12227",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 10.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__kessel_kessel_pelletsbeh\u00e4lter_saugzeitpunkt_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Pelletsbeh\u00e4lter > Saugzeitpunkt",
+        "unit": "minutes_since_midnight",
+        "url": "/40/10021/0/0/12152",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 1,
+          "scaled_max_value": 1439.0,
+          "scaled_min_value": 0.0
+        },
+        "value": "19:00"
+      },
+      "eta_192_168_0_25__kessel_kessel_restsauerstoff_o2_soll_lin_x1_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Restsauerstoff > O2 Soll > Lin x1",
+        "unit": "%",
+        "url": "/40/10021/12004/0/1051",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 30.0,
+          "scaled_min_value": 30.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__kessel_kessel_restsauerstoff_o2_soll_lin_x2_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Restsauerstoff > O2 Soll > Lin x2",
+        "unit": "%",
+        "url": "/40/10021/12004/0/1053",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 100.0
+        },
+        "value": 100.0
+      },
+      "eta_192_168_0_25__kessel_kessel_restsauerstoff_o2_soll_lin_y1_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Restsauerstoff > O2 Soll > Lin y1",
+        "unit": "%",
+        "url": "/40/10021/12004/0/1052",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 100,
+          "scaled_max_value": 15.0,
+          "scaled_min_value": 7.0
+        },
+        "value": 9.5
+      },
+      "eta_192_168_0_25__kessel_kessel_restsauerstoff_o2_soll_lin_y2_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Restsauerstoff > O2 Soll > Lin y2",
+        "unit": "%",
+        "url": "/40/10021/12004/0/1054",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 100,
+          "scaled_max_value": 15.0,
+          "scaled_min_value": 6.0
+        },
+        "value": 7.0
+      },
+      "eta_192_168_0_25__kessel_kessel_vorlaufregler_1_anforderungsdifferenz_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Vorlaufregler 1 > Anforderungsdifferenz",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/0/12020",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 20.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 5.0
+      },
+      "eta_192_168_0_25__kessel_z\u00e4hlerst\u00e4nde_inhalt_pelletsbeh\u00e4lter_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Z\u00e4hlerst\u00e4nde > Inhalt Pelletsbeh\u00e4lter",
+        "unit": "kg",
+        "url": "/40/10021/0/0/12011",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 0.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 28.8
+      },
+      "eta_192_168_0_25__lagerum._vorrat_vorrat_warngrenze_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "LagerUm. > Vorrat > Vorrat Warngrenze",
+        "unit": "kg",
+        "url": "/40/10211/0/0/12042",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100000.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 1000.0
+      },
+      "eta_192_168_0_25__lagerum._vorrat_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "LagerUm. > Vorrat",
+        "unit": "kg",
+        "url": "/40/10211/0/0/12015",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100000.0,
+          "scaled_min_value": -100000.0
+        },
+        "value": 2728.9
+      },
+      "eta_192_168_0_25__sys_antiblockierschutz_zu_welcher_uhrzeit?_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Sys > Antiblockierschutz > zu welcher Uhrzeit?",
+        "unit": "minutes_since_midnight",
+        "url": "/120/10241/0/0/14244",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 1,
+          "scaled_max_value": 1439.0,
+          "scaled_min_value": 0.0
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__sys_au\u00dfentemperatur_au\u00dfentemperaturf\u00fchler_fixwert_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Sys > Au\u00dfentemperatur > Au\u00dfentemperaturf\u00fchler > Fixwert",
+        "unit": "\u00b0C",
+        "url": "/120/10241/0/11127/2054",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 200.0,
+          "scaled_min_value": -100.0
+        },
+        "value": -5.0
+      },
+      "eta_192_168_0_25__sys_au\u00dfentemperatur_au\u00dfentemperaturf\u00fchler_kalibrierwert_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Sys > Au\u00dfentemperatur > Au\u00dfentemperaturf\u00fchler > Kalibrierwert",
+        "unit": "\u00b0C",
+        "url": "/120/10241/0/11127/2049",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 5.0,
+          "scaled_min_value": -5.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_eing\u00e4nge_warmwasserspeicher_fixwert_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Eing\u00e4nge > Warmwasserspeicher > Fixwert",
+        "unit": "\u00b0C",
+        "url": "/120/10111/0/11129/2054",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 200.0,
+          "scaled_min_value": -100.0
+        },
+        "value": 53.0
+      },
+      "eta_192_168_0_25__ww_eing\u00e4nge_warmwasserspeicher_kalibrierwert_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Eing\u00e4nge > Warmwasserspeicher > Kalibrierwert",
+        "unit": "\u00b0C",
+        "url": "/120/10111/0/11129/2049",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 5.0,
+          "scaled_min_value": -5.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_einschaltdifferenz_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Einschaltdifferenz",
+        "unit": "\u00b0C",
+        "url": "/120/10111/0/0/12133",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 30.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 20.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_laden_mit_anderen_verbrauchern_einschaltdifferenz_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Laden mit anderen Verbrauchern > Einschaltdifferenz",
+        "unit": "\u00b0C",
+        "url": "/120/10111/0/0/13535",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 30.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 5.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_dienstag_wert_au\u00dferhalb_der_zeitfenster_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Dienstag > Wert au\u00dferhalb der Zeitfenster",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1112",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_donnerstag_wert_au\u00dferhalb_der_zeitfenster_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Donnerstag > Wert au\u00dferhalb der Zeitfenster",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1114",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_freitag_wert_au\u00dferhalb_der_zeitfenster_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Freitag > Wert au\u00dferhalb der Zeitfenster",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1115",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_mittwoch_wert_au\u00dferhalb_der_zeitfenster_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Mittwoch > Wert au\u00dferhalb der Zeitfenster",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1113",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_montag_wert_au\u00dferhalb_der_zeitfenster_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Montag > Wert au\u00dferhalb der Zeitfenster",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1111",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_samstag_wert_au\u00dferhalb_der_zeitfenster_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Samstag > Wert au\u00dferhalb der Zeitfenster",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1116",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_sonntag_wert_au\u00dferhalb_der_zeitfenster_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Sonntag > Wert au\u00dferhalb der Zeitfenster",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1117",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_solltemperatur_f\u00fcr_'sofort_laden'_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Solltemperatur f\u00fcr 'Sofort laden'",
+        "unit": "\u00b0C",
+        "url": "/120/10111/0/0/14257",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 50.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_temperaturwarnung_1_differenz_warnung_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Temperaturwarnung 1 > Differenz Warnung",
+        "unit": "\u00b0C",
+        "url": "/120/10111/0/0/13039",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 80.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_warmwasserspeicher_max._writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Warmwasserspeicher max.",
+        "unit": "\u00b0C",
+        "url": "/120/10111/0/0/12169",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 75.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_warmwasserspeicher_soll_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Warmwasserspeicher Soll",
+        "unit": "\u00b0C",
+        "url": "/120/10111/0/0/12132",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 55.0
+      }
+    },
+    "chosen_float_sensors": [
+      "eta_192_168_0_25__sys_au\u00dfentemperatur",
+      "eta_192_168_0_25__kessel_kessel_pelletsbeh\u00e4lter_saugzeitpunkt",
+      "eta_192_168_0_25__kessel_kessel_abgas"
+    ],
+    "chosen_switches": [
+      "eta_192_168_0_25__kessel_sonstiges_ein/aus_taste"
+    ],
+    "chosen_text_sensors": [
+      "eta_192_168_0_25__kessel_kessel"
+    ],
+    "chosen_writable_sensors": [
+      "eta_192_168_0_25__fbh_eing\u00e4nge_vorlauf_fixwert_writable",
+      "eta_192_168_0_25__kessel_kessel_pelletsbeh\u00e4lter_saugzeitpunkt_writable"
+    ],
+    "enable_debug_logging": false,
+    "force_legacy_mode": false,
+    "host": "192.168.0.25",
+    "port": "9091"
+  },
+  "options": {
+    "FLOAT_DICT": {
+      "eta_192_168_0_25__fbh_ausg\u00e4nge_heizkreismischer": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Ausg\u00e4nge > Heizkreismischer",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/11125/0",
+        "valid_values": null,
+        "value": 32.6
+      },
+      "eta_192_168_0_25__fbh_ausg\u00e4nge_heizkreismischer_ist_temperatur": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Ausg\u00e4nge > Heizkreismischer > Ist Temperatur",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/11125/2121",
+        "valid_values": null,
+        "value": 32.6
+      },
+      "eta_192_168_0_25__fbh_ausg\u00e4nge_heizkreismischer_laufzeit_mischer": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Ausg\u00e4nge > Heizkreismischer > Laufzeit Mischer",
+        "unit": "s",
+        "url": "/120/10102/0/11125/2124",
+        "valid_values": null,
+        "value": 120.0
+      },
+      "eta_192_168_0_25__fbh_ausg\u00e4nge_heizkreismischer_position": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Ausg\u00e4nge > Heizkreismischer > Position",
+        "unit": "%",
+        "url": "/120/10102/0/11125/2127",
+        "valid_values": null,
+        "value": 21.6
+      },
+      "eta_192_168_0_25__fbh_ausg\u00e4nge_heizkreismischer_soll_temperatur": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Ausg\u00e4nge > Heizkreismischer > Soll Temperatur",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/11125/2120",
+        "valid_values": null,
+        "value": 33.0
+      },
+      "eta_192_168_0_25__fbh_ausg\u00e4nge_pumpe": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Ausg\u00e4nge > Pumpe",
+        "unit": "%",
+        "url": "/120/10102/0/11687/0",
+        "valid_values": null,
+        "value": 60.0
+      },
+      "eta_192_168_0_25__fbh_ausg\u00e4nge_pumpe_ausgang": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Ausg\u00e4nge > Pumpe > Ausgang",
+        "unit": "%",
+        "url": "/120/10102/0/11687/2130",
+        "valid_values": null,
+        "value": 60.0
+      },
+      "eta_192_168_0_25__fbh_eing\u00e4nge_au\u00dfentemperatur": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Eing\u00e4nge > Au\u00dfentemperatur",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12197",
+        "valid_values": null,
+        "value": -1.3
+      },
+      "eta_192_168_0_25__fbh_eing\u00e4nge_vorlauf": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Eing\u00e4nge > Vorlauf",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/11060/0",
+        "valid_values": null,
+        "value": 32.6
+      },
+      "eta_192_168_0_25__fbh_eing\u00e4nge_vorlauf_fixwert": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Eing\u00e4nge > Vorlauf > Fixwert",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/11060/2054",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__fbh_eing\u00e4nge_vorlauf_kalibrierwert": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Eing\u00e4nge > Vorlauf > Kalibrierwert",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/11060/2049",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 5.0,
+          "scaled_min_value": -5.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_anforderungsdifferenz": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Anforderungsdifferenz",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12109",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 50.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 3.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_au\u00dfentemperatur_verz\u00f6gert": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Au\u00dfentemperatur verz\u00f6gert",
+        "unit": "\u00b0C",
+        "url": "/120/10102/12095/0/0",
+        "valid_values": null,
+        "value": -1.3
+      },
+      "eta_192_168_0_25__fbh_heizkreis_au\u00dfentemperatur_verz\u00f6gert_lag_tf": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Au\u00dfentemperatur verz\u00f6gert > Lag Tf",
+        "unit": "s",
+        "url": "/120/10102/12095/0/1074",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_au\u00dfentemperatur_verz\u00f6gert_lag_x": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Au\u00dfentemperatur verz\u00f6gert > Lag x",
+        "unit": "\u00b0C",
+        "url": "/120/10102/12095/0/1071",
+        "valid_values": null,
+        "value": -1.3
+      },
+      "eta_192_168_0_25__fbh_heizkreis_au\u00dfentemperatur_verz\u00f6gert_lag_y": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Au\u00dfentemperatur verz\u00f6gert > Lag y",
+        "unit": "\u00b0C",
+        "url": "/120/10102/12095/0/1073",
+        "valid_values": null,
+        "value": -1.3
+      },
+      "eta_192_168_0_25__fbh_heizkreis_estrich_absenkung_alle": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Estrich > Absenkung alle",
+        "unit": "s",
+        "url": "/120/10102/0/0/12310",
+        "valid_values": null,
+        "value": 86400.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_estrich_absenkung_um": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Estrich > Absenkung um",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12309",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 20.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 3.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_estrich_anschlie\u00dfende_heizpause": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Estrich > anschlie\u00dfende Heizpause",
+        "unit": "s",
+        "url": "/120/10102/0/0/14687",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_estrich_anstieg_alle": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Estrich > Anstieg alle",
+        "unit": "s",
+        "url": "/120/10102/0/0/12306",
+        "valid_values": null,
+        "value": 86400.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_estrich_anstieg_um": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Estrich > Anstieg um",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12305",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 20.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 3.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_estrich_erneute_max._temp._halten": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Estrich > erneute Max. Temp. halten",
+        "unit": "s",
+        "url": "/120/10102/0/0/14689",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_estrich_erneute_max._temperatur": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Estrich > erneute Max. Temperatur",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/14688",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 60.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_estrich_letzte_\u00e4nderung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Estrich > Letzte \u00c4nderung",
+        "unit": "s",
+        "url": "/120/10102/0/0/12311",
+        "valid_values": null,
+        "value": 141646000.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_estrich_max._temp._halten": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Estrich > Max. Temp. halten",
+        "unit": "s",
+        "url": "/120/10102/0/0/12308",
+        "valid_values": null,
+        "value": 345600.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_estrich_max._temperatur": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Estrich > Max. Temperatur",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12307",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 60.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 40.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_estrich_vorlauf_soll": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Estrich > Vorlauf Soll",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12304",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 60.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 15.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizgrenze_f\u00fcr_'absenken'": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizgrenze f\u00fcr 'Absenken'",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12097",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 50.0,
+          "scaled_min_value": -50.0
+        },
+        "value": 2.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizgrenze_f\u00fcr_'heizen'": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizgrenze f\u00fcr 'Heizen'",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/14116",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 50.0,
+          "scaled_min_value": -50.0
+        },
+        "value": 22.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizkreismischer": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizkreismischer",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/13620",
+        "valid_values": null,
+        "value": 32.5
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizkreispumpe_pumpendrehzahl": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizkreispumpe > Pumpendrehzahl",
+        "unit": "%",
+        "url": "/120/10102/0/0/12258",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 10.0
+        },
+        "value": 60.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizkurve": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizkurve",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12111",
+        "valid_values": null,
+        "value": 33.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizkurve_aus_bei_heizkurve_unter": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizkurve > Aus bei Heizkurve unter",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/14133",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 50.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 22.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizkurve_schieber_position": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizkurve > Schieber Position",
+        "unit": "%",
+        "url": "/120/10102/0/0/12240",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": -100.0
+        },
+        "value": 50.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizkurve_vorlauf_absenkung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizkurve > Vorlauf Absenkung",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12107",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 50.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 3.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizkurve_vorlauf_bei_+10\u00b0c": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizkurve > Vorlauf bei +10\u00b0C",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12103",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 25.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizkurve_vorlauf_bei_-10\u00b0c": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizkurve > Vorlauf bei -10\u00b0C",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12104",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 33.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizlast": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizlast",
+        "unit": "W",
+        "url": "/120/10102/0/0/13100",
+        "valid_values": null,
+        "value": 9851.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizlast_gesamtfl\u00e4che": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizlast > Gesamtfl\u00e4che",
+        "unit": "m\u00b2",
+        "url": "/120/10102/0/0/13096",
+        "valid_values": null,
+        "value": 171.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizlast_heizlast_w\u00e4hrend_estrichtrocknung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizlast > Heizlast w\u00e4hrend Estrichtrocknung",
+        "unit": "kW",
+        "url": "/120/10102/0/0/13600",
+        "valid_values": null,
+        "value": 12.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizlast_nennheizlast": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizlast > Nennheizlast",
+        "unit": "W",
+        "url": "/120/10102/0/0/13099",
+        "valid_values": null,
+        "value": 11970.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizlast_spez._heizlast": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizlast > spez. Heizlast",
+        "unit": "W/m\u00b2",
+        "url": "/120/10102/0/0/13098",
+        "valid_values": null,
+        "value": 70.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_r\u00fcckstellzeit_f._'kommen'-taste": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > R\u00fcckstellzeit f. 'Kommen'-Taste",
+        "unit": "s",
+        "url": "/120/10102/0/0/13796",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_vorlauf": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Vorlauf",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12241",
+        "valid_values": null,
+        "value": 32.6
+      },
+      "eta_192_168_0_25__fbh_heizkreis_vorlauf_vorlauf_max": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Vorlauf > Vorlauf Max",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12108",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 45.0
+      },
+      "eta_192_168_0_25__hk_eing\u00e4nge_au\u00dfentemperatur": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Eing\u00e4nge > Au\u00dfentemperatur",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12197",
+        "valid_values": null,
+        "value": -1.3
+      },
+      "eta_192_168_0_25__hk_heizkreis_au\u00dfentemperatur_verz\u00f6gert": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Au\u00dfentemperatur verz\u00f6gert",
+        "unit": "\u00b0C",
+        "url": "/120/10101/12095/0/0",
+        "valid_values": null,
+        "value": -1.3
+      },
+      "eta_192_168_0_25__hk_heizkreis_au\u00dfentemperatur_verz\u00f6gert_lag_tf": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Au\u00dfentemperatur verz\u00f6gert > Lag Tf",
+        "unit": "s",
+        "url": "/120/10101/12095/0/1074",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_au\u00dfentemperatur_verz\u00f6gert_lag_x": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Au\u00dfentemperatur verz\u00f6gert > Lag x",
+        "unit": "\u00b0C",
+        "url": "/120/10101/12095/0/1071",
+        "valid_values": null,
+        "value": -1.3
+      },
+      "eta_192_168_0_25__hk_heizkreis_au\u00dfentemperatur_verz\u00f6gert_lag_y": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Au\u00dfentemperatur verz\u00f6gert > Lag y",
+        "unit": "\u00b0C",
+        "url": "/120/10101/12095/0/1073",
+        "valid_values": null,
+        "value": -1.3
+      },
+      "eta_192_168_0_25__hk_heizkreis_estrich_absenkung_alle": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Estrich > Absenkung alle",
+        "unit": "s",
+        "url": "/120/10101/0/0/12310",
+        "valid_values": null,
+        "value": 86400.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_estrich_absenkung_um": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Estrich > Absenkung um",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12309",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 20.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 3.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_estrich_anschlie\u00dfende_heizpause": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Estrich > anschlie\u00dfende Heizpause",
+        "unit": "s",
+        "url": "/120/10101/0/0/14687",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_estrich_anstieg_alle": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Estrich > Anstieg alle",
+        "unit": "s",
+        "url": "/120/10101/0/0/12306",
+        "valid_values": null,
+        "value": 86400.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_estrich_anstieg_um": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Estrich > Anstieg um",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12305",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 20.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 3.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_estrich_erneute_max._temp._halten": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Estrich > erneute Max. Temp. halten",
+        "unit": "s",
+        "url": "/120/10101/0/0/14689",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_estrich_erneute_max._temperatur": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Estrich > erneute Max. Temperatur",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/14688",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 60.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_estrich_letzte_\u00e4nderung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Estrich > Letzte \u00c4nderung",
+        "unit": "s",
+        "url": "/120/10101/0/0/12311",
+        "valid_values": null,
+        "value": 141676000.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_estrich_max._temp._halten": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Estrich > Max. Temp. halten",
+        "unit": "s",
+        "url": "/120/10101/0/0/12308",
+        "valid_values": null,
+        "value": 345600.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_estrich_max._temperatur": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Estrich > Max. Temperatur",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12307",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 60.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 40.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_estrich_vorlauf_soll": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Estrich > Vorlauf Soll",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12304",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 60.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 15.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizgrenze_f\u00fcr_'absenken'": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizgrenze f\u00fcr 'Absenken'",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12097",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 50.0,
+          "scaled_min_value": -50.0
+        },
+        "value": 2.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizgrenze_f\u00fcr_'heizen'": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizgrenze f\u00fcr 'Heizen'",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/14116",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 50.0,
+          "scaled_min_value": -50.0
+        },
+        "value": 21.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizkurve": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizkurve",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12111",
+        "valid_values": null,
+        "value": 26.5
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizkurve_aus_bei_heizkurve_unter": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizkurve > Aus bei Heizkurve unter",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/14133",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 50.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 22.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizkurve_schieber_position": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizkurve > Schieber Position",
+        "unit": "%",
+        "url": "/120/10101/0/0/12240",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": -100.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizkurve_vorlauf_absenkung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizkurve > Vorlauf Absenkung",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12107",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 50.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 3.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizkurve_vorlauf_bei_+10\u00b0c": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizkurve > Vorlauf bei +10\u00b0C",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12103",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 25.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizkurve_vorlauf_bei_-10\u00b0c": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizkurve > Vorlauf bei -10\u00b0C",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12104",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 33.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizlast": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizlast",
+        "unit": "W",
+        "url": "/120/10101/0/0/13100",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizlast_gesamtfl\u00e4che": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizlast > Gesamtfl\u00e4che",
+        "unit": "m\u00b2",
+        "url": "/120/10101/0/0/13096",
+        "valid_values": null,
+        "value": 125.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizlast_heizlast_w\u00e4hrend_estrichtrocknung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizlast > Heizlast w\u00e4hrend Estrichtrocknung",
+        "unit": "kW",
+        "url": "/120/10101/0/0/13600",
+        "valid_values": null,
+        "value": 8.8
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizlast_nennheizlast": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizlast > Nennheizlast",
+        "unit": "W",
+        "url": "/120/10101/0/0/13099",
+        "valid_values": null,
+        "value": 8750.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizlast_spez._heizlast": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizlast > spez. Heizlast",
+        "unit": "W/m\u00b2",
+        "url": "/120/10101/0/0/13098",
+        "valid_values": null,
+        "value": 70.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_r\u00fcckstellzeit_f._'kommen'-taste": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > R\u00fcckstellzeit f. 'Kommen'-Taste",
+        "unit": "s",
+        "url": "/120/10101/0/0/13796",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_vorlauf_vorlauf_max": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Vorlauf > Vorlauf Max",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12108",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 45.0
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_abgasgebl\u00e4se": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Abgasgebl\u00e4se",
+        "unit": "U/min",
+        "url": "/40/10021/0/0/12165",
+        "valid_values": null,
+        "value": 1180.0
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_abgasgebl\u00e4se_abgasgebl\u00e4se_ist_drehzahl": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Abgasgebl\u00e4se > Abgasgebl\u00e4se > Ist Drehzahl",
+        "unit": "U/min",
+        "url": "/40/10021/0/11120/2111",
+        "valid_values": null,
+        "value": 1184.0
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_abgasgebl\u00e4se_abgasgebl\u00e4se_soll_drehzahl": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Abgasgebl\u00e4se > Abgasgebl\u00e4se > Soll Drehzahl",
+        "unit": "U/min",
+        "url": "/40/10021/0/11120/2110",
+        "valid_values": null,
+        "value": 1184.0
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_kesselpumpe": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Kesselpumpe",
+        "unit": "%",
+        "url": "/40/10021/0/11123/0",
+        "valid_values": null,
+        "value": 65.3
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_kesselpumpe_ausgang": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Kesselpumpe > Ausgang",
+        "unit": "%",
+        "url": "/40/10021/0/11123/2130",
+        "valid_values": null,
+        "value": 65.3
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_luftschieber": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Luftschieber",
+        "unit": "%",
+        "url": "/40/10021/0/11115/0",
+        "valid_values": null,
+        "value": 0.6
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_luftschieber_ist_stellung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Luftschieber > Ist Stellung",
+        "unit": "%",
+        "url": "/40/10021/0/11115/2071",
+        "valid_values": null,
+        "value": 0.6
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_luftschieber_soll_stellung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Luftschieber > Soll Stellung",
+        "unit": "%",
+        "url": "/40/10021/0/11115/2070",
+        "valid_values": null,
+        "value": 100.0
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_stokerschnecke": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Stokerschnecke",
+        "unit": "%",
+        "url": "/40/10021/0/11030/0",
+        "valid_values": null,
+        "value": 22.3
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_stokerschnecke_erw\u00e4rmung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Stokerschnecke > Erw\u00e4rmung",
+        "unit": "%",
+        "url": "/40/10021/0/11030/2092",
+        "valid_values": null,
+        "value": 33.3
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_stokerschnecke_motor_strom": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Stokerschnecke > Motor Strom",
+        "unit": "A",
+        "url": "/40/10021/0/11030/2091",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_stokerschnecke_motor_strom_maximal_strom": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Stokerschnecke > Motor Strom > Maximal Strom",
+        "unit": "A",
+        "url": "/40/10021/0/11030/2096",
+        "valid_values": null,
+        "value": 0.18
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_stokerschnecke_motor_strom_mindest_strom": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Stokerschnecke > Motor Strom > Mindest Strom",
+        "unit": "A",
+        "url": "/40/10021/0/11030/2097",
+        "valid_values": null,
+        "value": 0.02
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_stokerschnecke_motor_strom_nennstrom": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Stokerschnecke > Motor Strom > Nennstrom",
+        "unit": "A",
+        "url": "/40/10021/0/11030/2098",
+        "valid_values": null,
+        "value": 0.165
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_stokerschnecke_schneckendrehzahl": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Stokerschnecke > Schneckendrehzahl",
+        "unit": "U/min",
+        "url": "/40/10021/0/11030/2099",
+        "valid_values": null,
+        "value": 2.0
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_stokerschnecke_taktrate": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Stokerschnecke > Taktrate",
+        "unit": "%",
+        "url": "/40/10021/0/11030/2090",
+        "valid_values": null,
+        "value": 22.3
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_umschaltventil_laufzeit": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Umschaltventil > Laufzeit",
+        "unit": "s",
+        "url": "/40/10021/0/0/12040",
+        "valid_values": null,
+        "value": 135.0
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_vorlaufmischer_1": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Vorlaufmischer 1",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11121/0",
+        "valid_values": null,
+        "value": 61.1
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_vorlaufmischer_1_ist_temperatur": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Vorlaufmischer 1 > Ist Temperatur",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11121/2121",
+        "valid_values": null,
+        "value": 61.1
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_vorlaufmischer_1_laufzeit_mischer": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Vorlaufmischer 1 > Laufzeit Mischer",
+        "unit": "s",
+        "url": "/40/10021/0/11121/2124",
+        "valid_values": null,
+        "value": 135.0
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_vorlaufmischer_1_position": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Vorlaufmischer 1 > Position",
+        "unit": "%",
+        "url": "/40/10021/0/11121/2127",
+        "valid_values": null,
+        "value": 56.4
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_vorlaufmischer_1_soll_temperatur": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Vorlaufmischer 1 > Soll Temperatur",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11121/2120",
+        "valid_values": null,
+        "value": 61.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_abgas": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Abgas",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11110/0",
+        "valid_values": null,
+        "value": 106.8
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_abgas_fixwert": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Abgas > Fixwert",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11110/2054",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 200.0,
+          "scaled_min_value": -100.0
+        },
+        "value": 120.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_abgas_kalibrierwert": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Abgas > Kalibrierwert",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11110/2049",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 5.0,
+          "scaled_min_value": -5.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_aschebox_ausschalt_verz.": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Aschebox > Ausschalt Verz.",
+        "unit": "s",
+        "url": "/40/10021/0/11034/2013",
+        "valid_values": null,
+        "value": 1.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_aschebox_einschalt_verz.": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Aschebox > Einschalt Verz.",
+        "unit": "s",
+        "url": "/40/10021/0/11034/2012",
+        "valid_values": null,
+        "value": 1.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_glutbett_ausschalt_verz.": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Glutbett > Ausschalt Verz.",
+        "unit": "s",
+        "url": "/40/10021/0/11036/2013",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_glutbett_einschalt_verz.": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Glutbett > Einschalt Verz.",
+        "unit": "s",
+        "url": "/40/10021/0/11036/2012",
+        "valid_values": null,
+        "value": 5.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11109/0",
+        "valid_values": null,
+        "value": 66.4
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel_fixwert": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel > Fixwert",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11109/2054",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 200.0,
+          "scaled_min_value": -100.0
+        },
+        "value": 70.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel_kalibrierwert": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel > Kalibrierwert",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11109/2049",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 5.0,
+          "scaled_min_value": -5.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel_unten": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel unten",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11122/0",
+        "valid_values": null,
+        "value": 55.9
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel_unten_fixwert": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel unten > Fixwert",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11122/2054",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 200.0,
+          "scaled_min_value": -100.0
+        },
+        "value": 55.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel_unten_kalibrierwert": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel unten > Kalibrierwert",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11122/2049",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 5.0,
+          "scaled_min_value": -5.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel_vorlauf_1": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel Vorlauf 1",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11058/0",
+        "valid_values": null,
+        "value": 61.4
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel_vorlauf_1_fixwert": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel Vorlauf 1 > Fixwert",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11058/2054",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 200.0,
+          "scaled_min_value": -100.0
+        },
+        "value": 60.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel_vorlauf_1_kalibrierwert": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel Vorlauf 1 > Kalibrierwert",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11058/2049",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 5.0,
+          "scaled_min_value": -5.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kesseldruck": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kesseldruck",
+        "unit": "bar",
+        "url": "/40/10021/0/0/12180",
+        "valid_values": null,
+        "value": 1.36
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kesseldruck_kesseldruck": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kesseldruck > Kesseldruck",
+        "unit": "V",
+        "url": "/40/10021/0/11135/0",
+        "valid_values": null,
+        "value": 1.52
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_messblende": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Messblende",
+        "unit": "Pa",
+        "url": "/40/10021/0/0/12166",
+        "valid_values": null,
+        "value": 7.5
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_messblende_messblende": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Messblende > Messblende",
+        "unit": "V",
+        "url": "/40/10021/0/11134/0",
+        "valid_values": null,
+        "value": 0.66
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_messblende_mindestdruck": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Messblende > Mindestdruck",
+        "unit": "Pa",
+        "url": "/40/10021/0/0/12150",
+        "valid_values": null,
+        "value": 10.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_messblende_offset": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Messblende > Offset",
+        "unit": "Pa",
+        "url": "/40/10021/0/0/12167",
+        "valid_values": null,
+        "value": -4.5
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_not-aus_schalter_ausschalt_verz.": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Not-Aus Schalter > Ausschalt Verz.",
+        "unit": "s",
+        "url": "/40/10021/0/11032/2013",
+        "valid_values": null,
+        "value": 1.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_not-aus_schalter_einschalt_verz.": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Not-Aus Schalter > Einschalt Verz.",
+        "unit": "s",
+        "url": "/40/10021/0/11032/2012",
+        "valid_values": null,
+        "value": 1.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_pelletsbeh\u00e4lter_ausschalt_verz.": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Pelletsbeh\u00e4lter > Ausschalt Verz.",
+        "unit": "s",
+        "url": "/40/10021/0/11037/2013",
+        "valid_values": null,
+        "value": 1.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_pelletsbeh\u00e4lter_einschalt_verz.": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Pelletsbeh\u00e4lter > Einschalt Verz.",
+        "unit": "s",
+        "url": "/40/10021/0/11037/2012",
+        "valid_values": null,
+        "value": 1.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_restsauerstoff": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Restsauerstoff",
+        "unit": "%",
+        "url": "/40/10021/0/11108/0",
+        "valid_values": null,
+        "value": 8.3
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_restsauerstoff_heizspannung_ist": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Restsauerstoff > Heizspannung Ist",
+        "unit": "V",
+        "url": "/40/10021/0/11108/2069",
+        "valid_values": null,
+        "value": 14.042
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_restsauerstoff_innenwiderstand": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Restsauerstoff > Innenwiderstand",
+        "unit": "Ohm",
+        "url": "/40/10021/0/11108/2058",
+        "valid_values": null,
+        "value": 201.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_restsauerstoff_kalibrierung_kalibrier_intervall": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Restsauerstoff > Kalibrierung > Kalibrier Intervall",
+        "unit": "s",
+        "url": "/40/10021/0/0/12246",
+        "valid_values": null,
+        "value": 1800000.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_restsauerstoff_kalibrierung_letzte_kalibrierung_bei": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Restsauerstoff > Kalibrierung > Letzte Kalibrierung bei",
+        "unit": "s",
+        "url": "/40/10021/0/0/12247",
+        "valid_values": null,
+        "value": 51977500.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_restsauerstoff_kalibrierwert": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Restsauerstoff > Kalibrierwert",
+        "unit": "mV",
+        "url": "/40/10021/0/11108/2064",
+        "valid_values": null,
+        "value": 2.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_restsauerstoff_korrigiertes_signal": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Restsauerstoff > korrigiertes Signal",
+        "unit": "mV",
+        "url": "/40/10021/0/11108/2065",
+        "valid_values": null,
+        "value": 8.9
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_restsauerstoff_restsauerstoff": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Restsauerstoff > Restsauerstoff",
+        "unit": "%",
+        "url": "/40/10021/0/11108/2060",
+        "valid_values": null,
+        "value": 8.02
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_restsauerstoff_signal": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Restsauerstoff > Signal",
+        "unit": "mV",
+        "url": "/40/10021/0/11108/2066",
+        "valid_values": null,
+        "value": 6.1
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_restsauerstoff_verz\u00f6gerung_(tf)": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Restsauerstoff > Verz\u00f6gerung (Tf)",
+        "unit": "s",
+        "url": "/40/10021/0/11108/2053",
+        "valid_values": null,
+        "value": 1.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_stb_ausschalt_verz.": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > STB > Ausschalt Verz.",
+        "unit": "s",
+        "url": "/40/10021/0/11033/2013",
+        "valid_values": null,
+        "value": 1.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_stb_einschalt_verz.": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > STB > Einschalt Verz.",
+        "unit": "s",
+        "url": "/40/10021/0/11033/2012",
+        "valid_values": null,
+        "value": 1.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_wassermangel_ausschalt_verz.": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Wassermangel > Ausschalt Verz.",
+        "unit": "s",
+        "url": "/40/10021/0/11031/2013",
+        "valid_values": null,
+        "value": 1.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_wassermangel_einschalt_verz.": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Wassermangel > Einschalt Verz.",
+        "unit": "s",
+        "url": "/40/10021/0/11031/2012",
+        "valid_values": null,
+        "value": 1.0
+      },
+      "eta_192_168_0_25__kessel_kessel_abgas": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Abgas",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/0/12162",
+        "valid_values": null,
+        "value": 106.7
+      },
+      "eta_192_168_0_25__kessel_kessel_abgas_abgas_max": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Abgas > Abgas Max",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/0/12023",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 300.0,
+          "scaled_min_value": 100.0
+        },
+        "value": 180.0
+      },
+      "eta_192_168_0_25__kessel_kessel_abgas_emissionsmessung_dauer_der_messung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Abgas > Emissionsmessung > Dauer der Messung",
+        "unit": "s",
+        "url": "/40/10021/0/0/12118",
+        "valid_values": null,
+        "value": 2700.0
+      },
+      "eta_192_168_0_25__kessel_kessel_abgas_emissionsmessung_verriegelungsdauer": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Abgas > Emissionsmessung > Verriegelungsdauer",
+        "unit": "s",
+        "url": "/40/10021/0/0/13268",
+        "valid_values": null,
+        "value": 14400.0
+      },
+      "eta_192_168_0_25__kessel_kessel_abgas_emissionsmessung_vorw\u00e4rmdauer": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Abgas > Emissionsmessung > Vorw\u00e4rmdauer",
+        "unit": "s",
+        "url": "/40/10021/0/0/13481",
+        "valid_values": null,
+        "value": 1800.0
+      },
+      "eta_192_168_0_25__kessel_kessel_einschub": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Einschub",
+        "unit": "%",
+        "url": "/40/10021/0/0/12007",
+        "valid_values": null,
+        "value": 22.3
+      },
+      "eta_192_168_0_25__kessel_kessel_einschub_brennstoffverst\u00e4rkung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Einschub > Brennstoffverst\u00e4rkung",
+        "unit": "%",
+        "url": "/40/10021/0/0/12069",
+        "valid_values": null,
+        "value": 112.2
+      },
+      "eta_192_168_0_25__kessel_kessel_einschub_stoker_sekunden_pro_kg": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Einschub > Stoker Sekunden pro kg",
+        "unit": "s",
+        "url": "/40/10021/0/0/12043",
+        "valid_values": null,
+        "value": 580.0
+      },
+      "eta_192_168_0_25__kessel_kessel_entaschung_aschebox_leeren_nach": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Entaschung > Aschebox leeren nach",
+        "unit": "kg",
+        "url": "/40/10021/0/0/12120",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 5000.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 1000.0
+      },
+      "eta_192_168_0_25__kessel_kessel_entaschung_beginn_ruhezeit": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Entaschung > Beginn Ruhezeit",
+        "unit": "minutes_since_midnight",
+        "url": "/40/10021/0/0/12248",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 1,
+          "scaled_max_value": 1439.0,
+          "scaled_min_value": 0.0
+        },
+        "value": "21:00"
+      },
+      "eta_192_168_0_25__kessel_kessel_entaschung_dauer_ruhezeit": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Entaschung > Dauer Ruhezeit",
+        "unit": "s",
+        "url": "/40/10021/0/0/12249",
+        "valid_values": null,
+        "value": 36000.0
+      },
+      "eta_192_168_0_25__kessel_kessel_entaschung_entaschen_nach_max.": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Entaschung > Entaschen nach max.",
+        "unit": "kg",
+        "url": "/40/10021/0/0/12074",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 25.0
+      },
+      "eta_192_168_0_25__kessel_kessel_entaschung_entaschen_nach_min.": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Entaschung > Entaschen nach min.",
+        "unit": "kg",
+        "url": "/40/10021/0/0/12073",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 15.0
+      },
+      "eta_192_168_0_25__kessel_kessel_kessel": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Kessel",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/0/12161",
+        "valid_values": null,
+        "value": 65.6
+      },
+      "eta_192_168_0_25__kessel_kessel_kessel_ausschaltdifferenz": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Kessel > Ausschaltdifferenz",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/0/12141",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 40.0,
+          "scaled_min_value": 3.0
+        },
+        "value": 15.0
+      },
+      "eta_192_168_0_25__kessel_kessel_kessel_kessel_min": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Kessel > Kessel Min",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/0/12022",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 50.0
+        },
+        "value": 55.0
+      },
+      "eta_192_168_0_25__kessel_kessel_kessel_kessel_soll": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Kessel > Kessel Soll",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/0/12001",
+        "valid_values": null,
+        "value": 66.0
+      },
+      "eta_192_168_0_25__kessel_kessel_kessel_mindest_laufzeit": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Kessel > Mindest Laufzeit",
+        "unit": "s",
+        "url": "/40/10021/0/0/12226",
+        "valid_values": null,
+        "value": 1800.0
+      },
+      "eta_192_168_0_25__kessel_kessel_kessel_unten": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Kessel unten",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/0/12300",
+        "valid_values": null,
+        "value": 55.7
+      },
+      "eta_192_168_0_25__kessel_kessel_kesseldruck_maximaler_wasserdruck": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Kesseldruck > Maximaler Wasserdruck",
+        "unit": "bar",
+        "url": "/40/10021/0/0/12171",
+        "valid_values": null,
+        "value": 2.8
+      },
+      "eta_192_168_0_25__kessel_kessel_kesseldruck_mindestdruck": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Kesseldruck > Mindestdruck",
+        "unit": "bar",
+        "url": "/40/10021/0/0/12170",
+        "valid_values": null,
+        "value": 0.8
+      },
+      "eta_192_168_0_25__kessel_kessel_kesseldruck_wasserdruck_nachf\u00fcllen_ab": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Kesseldruck > Wasserdruck Nachf\u00fcllen ab",
+        "unit": "bar",
+        "url": "/40/10021/0/0/12172",
+        "valid_values": null,
+        "value": 1.2
+      },
+      "eta_192_168_0_25__kessel_kessel_kessellaufmeldung_nachlaufzeit": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Kessellaufmeldung > Nachlaufzeit",
+        "unit": "s",
+        "url": "/40/10021/0/0/12110",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__kessel_kessel_kesselpumpe_maximal_drehzahl": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Kesselpumpe > Maximal Drehzahl",
+        "unit": "%",
+        "url": "/40/10021/0/0/12368",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 10.0
+        },
+        "value": 100.0
+      },
+      "eta_192_168_0_25__kessel_kessel_kesselpumpe_mindest_drehzahl": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Kesselpumpe > Mindest Drehzahl",
+        "unit": "%",
+        "url": "/40/10021/0/0/12227",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 10.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__kessel_kessel_pelletsbeh\u00e4lter_berechnete_saugzeit_max": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Pelletsbeh\u00e4lter > berechnete Saugzeit Max",
+        "unit": "s",
+        "url": "/40/10021/0/0/14635",
+        "valid_values": null,
+        "value": 188.0
+      },
+      "eta_192_168_0_25__kessel_kessel_pelletsbeh\u00e4lter_nachlauf_austragschnecke": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Pelletsbeh\u00e4lter > Nachlauf Austragschnecke",
+        "unit": "s",
+        "url": "/40/10021/0/0/12064",
+        "valid_values": null,
+        "value": 2.0
+      },
+      "eta_192_168_0_25__kessel_kessel_pelletsbeh\u00e4lter_saugzeit_max": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Pelletsbeh\u00e4lter > Saugzeit Max",
+        "unit": "s",
+        "url": "/40/10021/0/0/12061",
+        "valid_values": null,
+        "value": 360.0
+      },
+      "eta_192_168_0_25__kessel_kessel_pelletsbeh\u00e4lter_saugzeitpunkt": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Pelletsbeh\u00e4lter > Saugzeitpunkt",
+        "unit": "minutes_since_midnight",
+        "url": "/40/10021/0/0/12152",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 1,
+          "scaled_max_value": 1439.0,
+          "scaled_min_value": 0.0
+        },
+        "value": "19:00"
+      },
+      "eta_192_168_0_25__kessel_kessel_restsauerstoff": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Restsauerstoff",
+        "unit": "%",
+        "url": "/40/10021/0/0/12164",
+        "valid_values": null,
+        "value": 9.39
+      },
+      "eta_192_168_0_25__kessel_kessel_restsauerstoff_o2_soll": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Restsauerstoff > O2 Soll",
+        "unit": "%",
+        "url": "/40/10021/12004/0/0",
+        "valid_values": null,
+        "value": 8.94
+      },
+      "eta_192_168_0_25__kessel_kessel_restsauerstoff_o2_soll_lin_x": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Restsauerstoff > O2 Soll > Lin x",
+        "unit": "%",
+        "url": "/40/10021/12004/0/1050",
+        "valid_values": null,
+        "value": 45.9
+      },
+      "eta_192_168_0_25__kessel_kessel_restsauerstoff_o2_soll_lin_x1": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Restsauerstoff > O2 Soll > Lin x1",
+        "unit": "%",
+        "url": "/40/10021/12004/0/1051",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 30.0,
+          "scaled_min_value": 30.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__kessel_kessel_restsauerstoff_o2_soll_lin_x2": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Restsauerstoff > O2 Soll > Lin x2",
+        "unit": "%",
+        "url": "/40/10021/12004/0/1053",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 100.0
+        },
+        "value": 100.0
+      },
+      "eta_192_168_0_25__kessel_kessel_restsauerstoff_o2_soll_lin_y": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Restsauerstoff > O2 Soll > Lin y",
+        "unit": "%",
+        "url": "/40/10021/12004/0/1055",
+        "valid_values": null,
+        "value": 8.94
+      },
+      "eta_192_168_0_25__kessel_kessel_restsauerstoff_o2_soll_lin_y1": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Restsauerstoff > O2 Soll > Lin y1",
+        "unit": "%",
+        "url": "/40/10021/12004/0/1052",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 100,
+          "scaled_max_value": 15.0,
+          "scaled_min_value": 7.0
+        },
+        "value": 9.5
+      },
+      "eta_192_168_0_25__kessel_kessel_restsauerstoff_o2_soll_lin_y2": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Restsauerstoff > O2 Soll > Lin y2",
+        "unit": "%",
+        "url": "/40/10021/12004/0/1054",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 100,
+          "scaled_max_value": 15.0,
+          "scaled_min_value": 6.0
+        },
+        "value": 7.0
+      },
+      "eta_192_168_0_25__kessel_kessel_vorlaufregler_1_anforderungsdifferenz": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Vorlaufregler 1 > Anforderungsdifferenz",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/0/12020",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 20.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 5.0
+      },
+      "eta_192_168_0_25__kessel_kessel_vorlaufregler_1_angeforderte_leistung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Vorlaufregler 1 > Angeforderte Leistung",
+        "unit": "kW",
+        "url": "/40/10021/0/0/12077",
+        "valid_values": null,
+        "value": 9.8
+      },
+      "eta_192_168_0_25__kessel_kessel_vorlaufregler_1_angeforderte_temperatur": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Vorlaufregler 1 > Angeforderte Temperatur",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/0/12006",
+        "valid_values": null,
+        "value": 61.0
+      },
+      "eta_192_168_0_25__kessel_kessel_z\u00fcndung_heizversuch_max": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Z\u00fcndung > Heizversuch Max",
+        "unit": "s",
+        "url": "/40/10021/0/0/12046",
+        "valid_values": null,
+        "value": 300.0
+      },
+      "eta_192_168_0_25__kessel_kessel_z\u00fcndung_maximale_z\u00fcnddauer": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Z\u00fcndung > Maximale Z\u00fcnddauer",
+        "unit": "s",
+        "url": "/40/10021/0/0/12048",
+        "valid_values": null,
+        "value": 900.0
+      },
+      "eta_192_168_0_25__kessel_kessel_z\u00fcndung_warmstart_zeit": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Z\u00fcndung > Warmstart Zeit",
+        "unit": "s",
+        "url": "/40/10021/0/0/12045",
+        "valid_values": null,
+        "value": 1800.0
+      },
+      "eta_192_168_0_25__kessel_z\u00e4hlerst\u00e4nde_gesamtverbrauch": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Z\u00e4hlerst\u00e4nde > Gesamtverbrauch",
+        "unit": "kg",
+        "url": "/40/10021/0/0/12016",
+        "valid_values": null,
+        "value": 13349.7
+      },
+      "eta_192_168_0_25__kessel_z\u00e4hlerst\u00e4nde_inhalt_pelletsbeh\u00e4lter": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Z\u00e4hlerst\u00e4nde > Inhalt Pelletsbeh\u00e4lter",
+        "unit": "kg",
+        "url": "/40/10021/0/0/12011",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 0.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 28.8
+      },
+      "eta_192_168_0_25__kessel_z\u00e4hlerst\u00e4nde_laufzeit_abgasgebl\u00e4se": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Z\u00e4hlerst\u00e4nde > Laufzeit Abgasgebl\u00e4se",
+        "unit": "s",
+        "url": "/40/10021/0/0/12299",
+        "valid_values": null,
+        "value": 52630300.0
+      },
+      "eta_192_168_0_25__kessel_z\u00e4hlerst\u00e4nde_laufzeit_entaschung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Z\u00e4hlerst\u00e4nde > Laufzeit Entaschung",
+        "unit": "s",
+        "url": "/40/10021/0/0/12155",
+        "valid_values": null,
+        "value": 355450.0
+      },
+      "eta_192_168_0_25__kessel_z\u00e4hlerst\u00e4nde_laufzeit_saugturbine": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Z\u00e4hlerst\u00e4nde > Laufzeit Saugturbine",
+        "unit": "s",
+        "url": "/40/10021/0/0/12157",
+        "valid_values": null,
+        "value": 54068.0
+      },
+      "eta_192_168_0_25__kessel_z\u00e4hlerst\u00e4nde_laufzeit_stoker": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Z\u00e4hlerst\u00e4nde > Laufzeit Stoker",
+        "unit": "s",
+        "url": "/40/10021/0/0/12154",
+        "valid_values": null,
+        "value": 7743040.0
+      },
+      "eta_192_168_0_25__kessel_z\u00e4hlerst\u00e4nde_laufzeit_z\u00fcndung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Z\u00e4hlerst\u00e4nde > Laufzeit Z\u00fcndung",
+        "unit": "s",
+        "url": "/40/10021/0/0/12156",
+        "valid_values": null,
+        "value": 2096940.0
+      },
+      "eta_192_168_0_25__kessel_z\u00e4hlerst\u00e4nde_laufzeit_z\u00fcndung_dauer_der_letzten_z\u00fcndung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Z\u00e4hlerst\u00e4nde > Laufzeit Z\u00fcndung > Dauer der letzten Z\u00fcndung",
+        "unit": "s",
+        "url": "/40/10021/0/0/13346",
+        "valid_values": null,
+        "value": 139.0
+      },
+      "eta_192_168_0_25__kessel_z\u00e4hlerst\u00e4nde_verbrauch_seit_aschebox_leeren": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Z\u00e4hlerst\u00e4nde > Verbrauch seit Aschebox leeren",
+        "unit": "kg",
+        "url": "/40/10021/0/0/12013",
+        "valid_values": null,
+        "value": 574.9
+      },
+      "eta_192_168_0_25__kessel_z\u00e4hlerst\u00e4nde_verbrauch_seit_entaschung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Z\u00e4hlerst\u00e4nde > Verbrauch seit Entaschung",
+        "unit": "kg",
+        "url": "/40/10021/0/0/12012",
+        "valid_values": null,
+        "value": 23.4
+      },
+      "eta_192_168_0_25__kessel_z\u00e4hlerst\u00e4nde_verbrauch_seit_wartung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Z\u00e4hlerst\u00e4nde > Verbrauch seit Wartung",
+        "unit": "kg",
+        "url": "/40/10021/0/0/12014",
+        "valid_values": null,
+        "value": 1593.2
+      },
+      "eta_192_168_0_25__kessel_z\u00e4hlerst\u00e4nde_volllaststunden": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Z\u00e4hlerst\u00e4nde > Volllaststunden",
+        "unit": "s",
+        "url": "/40/10021/0/0/12153",
+        "valid_values": null,
+        "value": 24918200.0
+      },
+      "eta_192_168_0_25__kessel_z\u00e4hlerst\u00e4nde_z\u00e4hler_sicherheitspumpenlauf_laufzeit_sicherheitspumpenlauf": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Z\u00e4hlerst\u00e4nde > Z\u00e4hler Sicherheitspumpenlauf > Laufzeit Sicherheitspumpenlauf",
+        "unit": "s",
+        "url": "/40/10021/0/0/13643",
+        "valid_values": null,
+        "value": 52579.0
+      },
+      "eta_192_168_0_25__lagerum._austragung_sp\u00fcldauer": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "LagerUm. > Austragung > Sp\u00fcldauer",
+        "unit": "s",
+        "url": "/40/10211/0/0/12261",
+        "valid_values": null,
+        "value": 60.0
+      },
+      "eta_192_168_0_25__lagerum._eing\u00e4nge_nullpunktschalter_ausschalt_verz.": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "LagerUm. > Eing\u00e4nge > Nullpunktschalter > Ausschalt Verz.",
+        "unit": "s",
+        "url": "/40/10211/0/11133/2013",
+        "valid_values": null,
+        "value": 1.0
+      },
+      "eta_192_168_0_25__lagerum._eing\u00e4nge_nullpunktschalter_einschalt_verz.": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "LagerUm. > Eing\u00e4nge > Nullpunktschalter > Einschalt Verz.",
+        "unit": "s",
+        "url": "/40/10211/0/11133/2012",
+        "valid_values": null,
+        "value": 1.0
+      },
+      "eta_192_168_0_25__lagerum._vorrat": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "LagerUm. > Vorrat",
+        "unit": "kg",
+        "url": "/40/10211/0/0/12015",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100000.0,
+          "scaled_min_value": -100000.0
+        },
+        "value": 2728.9
+      },
+      "eta_192_168_0_25__lagerum._vorrat_vorrat_warngrenze": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "LagerUm. > Vorrat > Vorrat Warngrenze",
+        "unit": "kg",
+        "url": "/40/10211/0/0/12042",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100000.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 1000.0
+      },
+      "eta_192_168_0_25__sys_antiblockierschutz_zu_welcher_uhrzeit?": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Sys > Antiblockierschutz > zu welcher Uhrzeit?",
+        "unit": "minutes_since_midnight",
+        "url": "/120/10241/0/0/14244",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 1,
+          "scaled_max_value": 1439.0,
+          "scaled_min_value": 0.0
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__sys_au\u00dfentemperatur": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Sys > Au\u00dfentemperatur",
+        "unit": "\u00b0C",
+        "url": "/120/10241/0/0/12197",
+        "valid_values": null,
+        "value": -1.3
+      },
+      "eta_192_168_0_25__sys_au\u00dfentemperatur_au\u00dfentemperaturf\u00fchler": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Sys > Au\u00dfentemperatur > Au\u00dfentemperaturf\u00fchler",
+        "unit": "\u00b0C",
+        "url": "/120/10241/0/11127/0",
+        "valid_values": null,
+        "value": -1.3
+      },
+      "eta_192_168_0_25__sys_au\u00dfentemperatur_au\u00dfentemperaturf\u00fchler_fixwert": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Sys > Au\u00dfentemperatur > Au\u00dfentemperaturf\u00fchler > Fixwert",
+        "unit": "\u00b0C",
+        "url": "/120/10241/0/11127/2054",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 200.0,
+          "scaled_min_value": -100.0
+        },
+        "value": -5.0
+      },
+      "eta_192_168_0_25__sys_au\u00dfentemperatur_au\u00dfentemperaturf\u00fchler_kalibrierwert": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Sys > Au\u00dfentemperatur > Au\u00dfentemperaturf\u00fchler > Kalibrierwert",
+        "unit": "\u00b0C",
+        "url": "/120/10241/0/11127/2049",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 5.0,
+          "scaled_min_value": -5.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_eing\u00e4nge_warmwasserspeicher": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Eing\u00e4nge > Warmwasserspeicher",
+        "unit": "\u00b0C",
+        "url": "/120/10111/0/11129/0",
+        "valid_values": null,
+        "value": 57.3
+      },
+      "eta_192_168_0_25__ww_eing\u00e4nge_warmwasserspeicher_fixwert": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Eing\u00e4nge > Warmwasserspeicher > Fixwert",
+        "unit": "\u00b0C",
+        "url": "/120/10111/0/11129/2054",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 200.0,
+          "scaled_min_value": -100.0
+        },
+        "value": 53.0
+      },
+      "eta_192_168_0_25__ww_eing\u00e4nge_warmwasserspeicher_kalibrierwert": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Eing\u00e4nge > Warmwasserspeicher > Kalibrierwert",
+        "unit": "\u00b0C",
+        "url": "/120/10111/0/11129/2049",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 5.0,
+          "scaled_min_value": -5.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_einschaltdifferenz": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Einschaltdifferenz",
+        "unit": "\u00b0C",
+        "url": "/120/10111/0/0/12133",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 30.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 20.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_laden_mit_anderen_verbrauchern_einschaltdifferenz": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Laden mit anderen Verbrauchern > Einschaltdifferenz",
+        "unit": "\u00b0C",
+        "url": "/120/10111/0/0/13535",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 30.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 5.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_dienstag_wert_au\u00dferhalb_der_zeitfenster": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Dienstag > Wert au\u00dferhalb der Zeitfenster",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1112",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_dienstag_zeitfenster_1": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Dienstag > Zeitfenster 1",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1086",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_dienstag_zeitfenster_2": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Dienstag > Zeitfenster 2",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1087",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_dienstag_zeitfenster_3": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Dienstag > Zeitfenster 3",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1088",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_donnerstag_wert_au\u00dferhalb_der_zeitfenster": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Donnerstag > Wert au\u00dferhalb der Zeitfenster",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1114",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_donnerstag_zeitfenster_1": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Donnerstag > Zeitfenster 1",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1094",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_donnerstag_zeitfenster_2": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Donnerstag > Zeitfenster 2",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1095",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_donnerstag_zeitfenster_3": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Donnerstag > Zeitfenster 3",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1096",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_freitag_wert_au\u00dferhalb_der_zeitfenster": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Freitag > Wert au\u00dferhalb der Zeitfenster",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1115",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_freitag_zeitfenster_1": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Freitag > Zeitfenster 1",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1098",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_freitag_zeitfenster_2": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Freitag > Zeitfenster 2",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1099",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_freitag_zeitfenster_3": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Freitag > Zeitfenster 3",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1100",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_mittwoch_wert_au\u00dferhalb_der_zeitfenster": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Mittwoch > Wert au\u00dferhalb der Zeitfenster",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1113",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_mittwoch_zeitfenster_1": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Mittwoch > Zeitfenster 1",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1090",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_mittwoch_zeitfenster_2": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Mittwoch > Zeitfenster 2",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1091",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_mittwoch_zeitfenster_3": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Mittwoch > Zeitfenster 3",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1092",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_montag_wert_au\u00dferhalb_der_zeitfenster": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Montag > Wert au\u00dferhalb der Zeitfenster",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1111",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_montag_zeitfenster_1": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Montag > Zeitfenster 1",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1082",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_montag_zeitfenster_2": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Montag > Zeitfenster 2",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1083",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_montag_zeitfenster_3": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Montag > Zeitfenster 3",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1084",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_samstag_wert_au\u00dferhalb_der_zeitfenster": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Samstag > Wert au\u00dferhalb der Zeitfenster",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1116",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_samstag_zeitfenster_1": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Samstag > Zeitfenster 1",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1102",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_samstag_zeitfenster_2": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Samstag > Zeitfenster 2",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1103",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_samstag_zeitfenster_3": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Samstag > Zeitfenster 3",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1104",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_sonntag_wert_au\u00dferhalb_der_zeitfenster": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Sonntag > Wert au\u00dferhalb der Zeitfenster",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1117",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_sonntag_zeitfenster_1": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Sonntag > Zeitfenster 1",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1106",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_sonntag_zeitfenster_2": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Sonntag > Zeitfenster 2",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1107",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_sonntag_zeitfenster_3": {
+        "endpoint_type": "TIMESLOT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Sonntag > Zeitfenster 3",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1108",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_temperatur": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Temperatur",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1110",
+        "valid_values": null,
+        "value": 55.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_registerleistung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Registerleistung",
+        "unit": "kW",
+        "url": "/120/10111/0/0/13150",
+        "valid_values": null,
+        "value": 7.7
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_solltemperatur_f\u00fcr_'sofort_laden'": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Solltemperatur f\u00fcr 'Sofort laden'",
+        "unit": "\u00b0C",
+        "url": "/120/10111/0/0/14257",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 50.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_temperaturwarnung_1_dauer_bis_warnung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Temperaturwarnung 1 > Dauer bis Warnung",
+        "unit": "s",
+        "url": "/120/10111/0/0/13166",
+        "valid_values": null,
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_temperaturwarnung_1_differenz_warnung": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Temperaturwarnung 1 > Differenz Warnung",
+        "unit": "\u00b0C",
+        "url": "/120/10111/0/0/13039",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 80.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_warmwasserspeicher": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Warmwasserspeicher",
+        "unit": "\u00b0C",
+        "url": "/120/10111/0/0/12271",
+        "valid_values": null,
+        "value": 57.3
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_warmwasserspeicher_max.": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Warmwasserspeicher max.",
+        "unit": "\u00b0C",
+        "url": "/120/10111/0/0/12169",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 75.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_warmwasserspeicher_soll": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Warmwasserspeicher Soll",
+        "unit": "\u00b0C",
+        "url": "/120/10111/0/0/12132",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 55.0
+      }
+    },
+    "SWITCHES_DICT": {
+      "eta_192_168_0_25__fbh_heizkreis_estrich_start_estrich_ausheizen": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Heizkreis > Estrich > Start Estrich ausheizen",
+        "unit": "",
+        "url": "/120/10102/0/0/12303",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__fbh_heizkreis_solar_absch\u00f6pfen": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Heizkreis > Solar absch\u00f6pfen",
+        "unit": "",
+        "url": "/120/10102/0/0/12652",
+        "valid_values": {
+          "off_value": 1800,
+          "on_value": 1801
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__fbh_heizkreis_vorrang_warmwasser": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Heizkreis > Vorrang Warmwasser",
+        "unit": "",
+        "url": "/120/10102/0/0/12178",
+        "valid_values": {
+          "off_value": 1800,
+          "on_value": 1801
+        },
+        "value": "Ja"
+      },
+      "eta_192_168_0_25__fbh_sonstiges_absenken_taste": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Sonstiges > Absenken Taste",
+        "unit": "",
+        "url": "/120/10102/0/0/12230",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__fbh_sonstiges_auto_taste": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Sonstiges > Auto Taste",
+        "unit": "",
+        "url": "/120/10102/0/0/12126",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__fbh_sonstiges_ein/aus_taste": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Sonstiges > Ein/Aus Taste",
+        "unit": "",
+        "url": "/120/10102/0/0/12080",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__fbh_sonstiges_gehen_taste": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Sonstiges > Gehen Taste",
+        "unit": "",
+        "url": "/120/10102/0/0/12231",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__fbh_sonstiges_heizen_taste": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Sonstiges > Heizen Taste",
+        "unit": "",
+        "url": "/120/10102/0/0/12125",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__fbh_sonstiges_kommen_taste": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Sonstiges > Kommen Taste",
+        "unit": "",
+        "url": "/120/10102/0/0/12218",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__hk_heizkreis_estrich_start_estrich_ausheizen": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "HK > Heizkreis > Estrich > Start Estrich ausheizen",
+        "unit": "",
+        "url": "/120/10101/0/0/12303",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__hk_heizkreis_solar_absch\u00f6pfen": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "HK > Heizkreis > Solar absch\u00f6pfen",
+        "unit": "",
+        "url": "/120/10101/0/0/12652",
+        "valid_values": {
+          "off_value": 1800,
+          "on_value": 1801
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__hk_heizkreis_vorrang_warmwasser": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "HK > Heizkreis > Vorrang Warmwasser",
+        "unit": "",
+        "url": "/120/10101/0/0/12178",
+        "valid_values": {
+          "off_value": 1800,
+          "on_value": 1801
+        },
+        "value": "Ja"
+      },
+      "eta_192_168_0_25__hk_sonstiges_absenken_taste": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "HK > Sonstiges > Absenken Taste",
+        "unit": "",
+        "url": "/120/10101/0/0/12230",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__hk_sonstiges_auto_taste": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "HK > Sonstiges > Auto Taste",
+        "unit": "",
+        "url": "/120/10101/0/0/12126",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__hk_sonstiges_ein/aus_taste": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "HK > Sonstiges > Ein/Aus Taste",
+        "unit": "",
+        "url": "/120/10101/0/0/12080",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__hk_sonstiges_gehen_taste": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "HK > Sonstiges > Gehen Taste",
+        "unit": "",
+        "url": "/120/10101/0/0/12231",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__hk_sonstiges_heizen_taste": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "HK > Sonstiges > Heizen Taste",
+        "unit": "",
+        "url": "/120/10101/0/0/12125",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__hk_sonstiges_kommen_taste": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "HK > Sonstiges > Kommen Taste",
+        "unit": "",
+        "url": "/120/10101/0/0/12218",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_abgasgebl\u00e4se_abgasgebl\u00e4se_notbetrieb": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Abgasgebl\u00e4se > Abgasgebl\u00e4se > Notbetrieb",
+        "unit": "",
+        "url": "/40/10021/0/11120/2400",
+        "valid_values": {
+          "off_value": 1070,
+          "on_value": 1071
+        },
+        "value": "Nein"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kesseldruck_kesseldruck_notbetrieb": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kesseldruck > Kesseldruck > Notbetrieb",
+        "unit": "",
+        "url": "/40/10021/0/11135/2400",
+        "valid_values": {
+          "off_value": 1070,
+          "on_value": 1071
+        },
+        "value": "Nein"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_messblende_messblende_notbetrieb": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Messblende > Messblende > Notbetrieb",
+        "unit": "",
+        "url": "/40/10021/0/11134/2400",
+        "valid_values": {
+          "off_value": 1070,
+          "on_value": 1071
+        },
+        "value": "Nein"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_restsauerstoff_kalibrierung_extra_kalibrieren": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Restsauerstoff > Kalibrierung > Extra Kalibrieren",
+        "unit": "",
+        "url": "/40/10021/0/0/12301",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_restsauerstoff_kalibrierung_kalibrierung_abbrechen": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Restsauerstoff > Kalibrierung > Kalibrierung abbrechen",
+        "unit": "",
+        "url": "/40/10021/0/0/13943",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_restsauerstoff_notbetrieb": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Restsauerstoff > Notbetrieb",
+        "unit": "",
+        "url": "/40/10021/0/11108/2400",
+        "valid_values": {
+          "off_value": 1070,
+          "on_value": 1071
+        },
+        "value": "Nein"
+      },
+      "eta_192_168_0_25__kessel_kessel_abgas_emissionsmessung_messung_deaktivieren": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel > Abgas > Emissionsmessung > Messung deaktivieren",
+        "unit": "",
+        "url": "/40/10021/0/0/13277",
+        "valid_values": {
+          "off_value": 1800,
+          "on_value": 1801
+        },
+        "value": "Nein"
+      },
+      "eta_192_168_0_25__kessel_kessel_einstellungen_brenner_verriegeln": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel > Einstellungen > Brenner verriegeln",
+        "unit": "",
+        "url": "/40/10021/0/0/12651",
+        "valid_values": {
+          "off_value": 1800,
+          "on_value": 1801
+        },
+        "value": "Nein"
+      },
+      "eta_192_168_0_25__kessel_kessel_entaschung_glutabbrand_sofort_beenden": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel > Entaschung > Glutabbrand sofort beenden",
+        "unit": "",
+        "url": "/40/10021/0/0/13951",
+        "valid_values": {
+          "off_value": 1800,
+          "on_value": 1801
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__kessel_kessel_pelletsbeh\u00e4lter_pelletsbeh\u00e4lter_auff\u00fcllen": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel > Pelletsbeh\u00e4lter > Pelletsbeh\u00e4lter auff\u00fcllen",
+        "unit": "",
+        "url": "/40/10021/0/0/12071",
+        "valid_values": {
+          "off_value": 1800,
+          "on_value": 1801
+        },
+        "value": "Nein"
+      },
+      "eta_192_168_0_25__kessel_kessel_restsauerstoff_o2_soll_extrapol": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel > Restsauerstoff > O2 Soll > Extrapol",
+        "unit": "",
+        "url": "/40/10021/12004/0/1056",
+        "valid_values": {
+          "off_value": 1800,
+          "on_value": 1801
+        },
+        "value": "Nein"
+      },
+      "eta_192_168_0_25__kessel_sonstiges_ein/aus_taste": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Sonstiges > Ein/Aus Taste",
+        "unit": "",
+        "url": "/40/10021/0/0/12080",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__kessel_sonstiges_entaschentaste": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Sonstiges > Entaschentaste",
+        "unit": "",
+        "url": "/40/10021/0/0/12112",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__kessel_z\u00e4hlerst\u00e4nde_verbrauch_seit_wartung_z\u00e4hler_r\u00fccksetzen_?": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Z\u00e4hlerst\u00e4nde > Verbrauch seit Wartung > Z\u00e4hler r\u00fccksetzen ?",
+        "unit": "",
+        "url": "/40/10021/0/0/12257",
+        "valid_values": {
+          "off_value": 1800,
+          "on_value": 1801
+        },
+        "value": "Nein"
+      },
+      "eta_192_168_0_25__lagerum._sonstiges_taste_vor": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "LagerUm. > Sonstiges > Taste Vor",
+        "unit": "",
+        "url": "/40/10211/0/0/12883",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__lagerum._sonstiges_taste_zur\u00fcck": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "LagerUm. > Sonstiges > Taste Zur\u00fcck",
+        "unit": "",
+        "url": "/40/10211/0/0/12884",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__sys_externe_st\u00f6rmeldung_anzeigen": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Sys > Externe St\u00f6rmeldung > Anzeigen",
+        "unit": "",
+        "url": "/120/10241/0/0/14871",
+        "valid_values": {
+          "off_value": 1800,
+          "on_value": 1801
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__sys_st\u00f6rmeldung_anzeigen": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Sys > St\u00f6rmeldung > Anzeigen",
+        "unit": "",
+        "url": "/120/10241/0/0/14870",
+        "valid_values": {
+          "off_value": 1800,
+          "on_value": 1801
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__ww_sonstiges_ein/aus_taste": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "WW > Sonstiges > Ein/Aus Taste",
+        "unit": "",
+        "url": "/120/10111/0/0/12080",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__ww_sonstiges_warmwasser_sofort_laden": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "WW > Sonstiges > Warmwasser sofort laden",
+        "unit": "",
+        "url": "/120/10111/0/0/12134",
+        "valid_values": {
+          "off_value": 1802,
+          "on_value": 1803
+        },
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_laden_mit_anderen_verbrauchern": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "WW > Warmwasserspeicher > Laden mit anderen Verbrauchern",
+        "unit": "",
+        "url": "/120/10111/0/0/12667",
+        "valid_values": {
+          "off_value": 1800,
+          "on_value": 1801
+        },
+        "value": "Nein"
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_solar_absch\u00f6pfen": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "WW > Warmwasserspeicher > Solar absch\u00f6pfen",
+        "unit": "",
+        "url": "/120/10111/0/0/12652",
+        "valid_values": {
+          "off_value": 1800,
+          "on_value": 1801
+        },
+        "value": "xxx"
+      }
+    },
+    "TEXT_DICT": {
+      "eta_192_168_0_25__fbh_ausg\u00e4nge_heizkreismischer_anforderung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Ausg\u00e4nge > Heizkreismischer > Anforderung",
+        "unit": "",
+        "url": "/120/10102/0/11125/2001",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__fbh_ausg\u00e4nge_heizkreismischer_zustand": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Ausg\u00e4nge > Heizkreismischer > Zustand",
+        "unit": "",
+        "url": "/120/10102/0/11125/2002",
+        "valid_values": null,
+        "value": "Halt"
+      },
+      "eta_192_168_0_25__fbh_ausg\u00e4nge_pumpe_anforderung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Ausg\u00e4nge > Pumpe > Anforderung",
+        "unit": "",
+        "url": "/120/10102/0/11687/2001",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__fbh_ausg\u00e4nge_pumpe_drehzahlsteuerung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Ausg\u00e4nge > Pumpe > Drehzahlsteuerung",
+        "unit": "",
+        "url": "/120/10102/0/11687/2133",
+        "valid_values": null,
+        "value": "Heizungspumpe (siehe Infotaste!)"
+      },
+      "eta_192_168_0_25__fbh_ausg\u00e4nge_pumpe_zustand": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Ausg\u00e4nge > Pumpe > Zustand",
+        "unit": "",
+        "url": "/120/10102/0/11687/2002",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__fbh_eing\u00e4nge_vorlauf_sensor_typ": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Eing\u00e4nge > Vorlauf > Sensor Typ",
+        "unit": "",
+        "url": "/120/10102/0/11060/2011",
+        "valid_values": {
+          "Analoger Raumf\u00fchler": 1116,
+          "KTY": 1114,
+          "KTY Au\u00dfenf\u00fchler": 1115,
+          "Pt1000": 1111,
+          "Pt1000 Abgasf\u00fchler": 1112,
+          "Pt1000 Au\u00dfenf\u00fchler": 1113
+        },
+        "value": "Pt1000"
+      },
+      "eta_192_168_0_25__fbh_eing\u00e4nge_vorlauf_zustand": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Eing\u00e4nge > Vorlauf > Zustand",
+        "unit": "",
+        "url": "/120/10102/0/11060/2002",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__fbh_heizkreis": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Heizkreis",
+        "unit": "",
+        "url": "/120/10102/0/0/19404",
+        "valid_values": null,
+        "value": "Heizen"
+      },
+      "eta_192_168_0_25__fbh_heizkreis_erg\u00e4nzung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Heizkreis > Erg\u00e4nzung",
+        "unit": "",
+        "url": "/120/10102/0/0/19391",
+        "valid_values": null,
+        "value": "0_4067"
+      },
+      "eta_192_168_0_25__fbh_heizkreis_estrich": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Heizkreis > Estrich",
+        "unit": "",
+        "url": "/120/10102/0/0/12302",
+        "valid_values": null,
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__fbh_heizkreis_estrich_am_ende": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Heizkreis > Estrich > am Ende",
+        "unit": "",
+        "url": "/120/10102/0/0/14686",
+        "valid_values": {
+          "Absenkbetrieb": 6612,
+          "Automatikbetrieb": 6611,
+          "ausschalten": 6610
+        },
+        "value": "Automatikbetrieb"
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizkreispumpe": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Heizkreis > Heizkreispumpe",
+        "unit": "",
+        "url": "/120/10102/0/0/13922",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizkurve_bei_niedriger_heizkurve": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Heizkreis > Heizkurve > bei niedriger Heizkurve",
+        "unit": "",
+        "url": "/120/10102/0/0/14052",
+        "valid_values": {
+          "Abschalten": 6080,
+          "Vorlauf Min halten": 6081
+        },
+        "value": "Abschalten"
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizzeiten": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Heizkreis > Heizzeiten",
+        "unit": "",
+        "url": "/120/10102/12113/0/0",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizzeiten_schaltzustand": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Heizkreis > Heizzeiten > Schaltzustand",
+        "unit": "",
+        "url": "/120/10102/12113/0/1109",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__fbh_heizkreistyp": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Heizkreistyp",
+        "unit": "",
+        "url": "/120/10102/0/0/12476",
+        "valid_values": {
+          "Allgemein": 1808,
+          "Fussbodenheizung": 1806,
+          "Radiatorenheizung": 1807
+        },
+        "value": "Fussbodenheizung"
+      },
+      "eta_192_168_0_25__fbh_sonstiges_heizkreis": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Fbh > Sonstiges > Heizkreis",
+        "unit": "",
+        "url": "/120/10102/0/0/12090",
+        "valid_values": null,
+        "value": "Ein Heizen"
+      },
+      "eta_192_168_0_25__hk_heizkreis": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "HK > Heizkreis",
+        "unit": "",
+        "url": "/120/10101/0/0/19404",
+        "valid_values": null,
+        "value": "Ausgeschaltet"
+      },
+      "eta_192_168_0_25__hk_heizkreis_erg\u00e4nzung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "HK > Heizkreis > Erg\u00e4nzung",
+        "unit": "",
+        "url": "/120/10101/0/0/19391",
+        "valid_values": null,
+        "value": "0_4067"
+      },
+      "eta_192_168_0_25__hk_heizkreis_estrich": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "HK > Heizkreis > Estrich",
+        "unit": "",
+        "url": "/120/10101/0/0/12302",
+        "valid_values": null,
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__hk_heizkreis_estrich_am_ende": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "HK > Heizkreis > Estrich > am Ende",
+        "unit": "",
+        "url": "/120/10101/0/0/14686",
+        "valid_values": {
+          "Absenkbetrieb": 6612,
+          "Automatikbetrieb": 6611,
+          "ausschalten": 6610
+        },
+        "value": "Automatikbetrieb"
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizkurve_bei_niedriger_heizkurve": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "HK > Heizkreis > Heizkurve > bei niedriger Heizkurve",
+        "unit": "",
+        "url": "/120/10101/0/0/14052",
+        "valid_values": {
+          "Abschalten": 6080,
+          "Vorlauf Min halten": 6081
+        },
+        "value": "Abschalten"
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizzeiten": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "HK > Heizkreis > Heizzeiten",
+        "unit": "",
+        "url": "/120/10101/12113/0/0",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizzeiten_schaltzustand": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "HK > Heizkreis > Heizzeiten > Schaltzustand",
+        "unit": "",
+        "url": "/120/10101/12113/0/1109",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__hk_heizkreistyp": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "HK > Heizkreistyp",
+        "unit": "",
+        "url": "/120/10101/0/0/12476",
+        "valid_values": {
+          "Allgemein": 1808,
+          "Fussbodenheizung": 1806,
+          "Radiatorenheizung": 1807
+        },
+        "value": "Allgemein"
+      },
+      "eta_192_168_0_25__hk_sonstiges_heizkreis": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "HK > Sonstiges > Heizkreis",
+        "unit": "",
+        "url": "/120/10101/0/0/12090",
+        "valid_values": null,
+        "value": "Aus Sommer"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_abgasgebl\u00e4se_abgasgebl\u00e4se": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Abgasgebl\u00e4se > Abgasgebl\u00e4se",
+        "unit": "",
+        "url": "/40/10021/0/11120/0",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_abgasgebl\u00e4se_abgasgebl\u00e4se_anforderung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Abgasgebl\u00e4se > Abgasgebl\u00e4se > Anforderung",
+        "unit": "",
+        "url": "/40/10021/0/11120/2001",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_abgasgebl\u00e4se_abgasgebl\u00e4se_drehzahlsteuerung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Abgasgebl\u00e4se > Abgasgebl\u00e4se > Drehzahlsteuerung",
+        "unit": "",
+        "url": "/40/10021/0/11120/2133",
+        "valid_values": {
+          "Phasenanschnitt": 1270,
+          "Pulspaket": 1271
+        },
+        "value": "Phasenanschnitt"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_abgasgebl\u00e4se_abgasgebl\u00e4se_zustand": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Abgasgebl\u00e4se > Abgasgebl\u00e4se > Zustand",
+        "unit": "",
+        "url": "/40/10021/0/11120/2002",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_entaschung_und_rost": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Entaschung und Rost",
+        "unit": "",
+        "url": "/40/10021/0/11048/0",
+        "valid_values": null,
+        "value": "Halt"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_entaschung_und_rost_anforderung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Entaschung und Rost > Anforderung",
+        "unit": "",
+        "url": "/40/10021/0/11048/2001",
+        "valid_values": null,
+        "value": "Halt"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_entaschung_und_rost_schalter": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Entaschung und Rost > Schalter",
+        "unit": "",
+        "url": "/40/10021/0/11048/2083",
+        "valid_values": null,
+        "value": "Ja"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_entaschung_und_rost_zustand": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Entaschung und Rost > Zustand",
+        "unit": "",
+        "url": "/40/10021/0/11048/2002",
+        "valid_values": null,
+        "value": "Halt"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_kesselpumpe_anforderung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Kesselpumpe > Anforderung",
+        "unit": "",
+        "url": "/40/10021/0/11123/2001",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_kesselpumpe_drehzahlsteuerung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Kesselpumpe > Drehzahlsteuerung",
+        "unit": "",
+        "url": "/40/10021/0/11123/2133",
+        "valid_values": {
+          "0-10V analog": 1285,
+          "Ein/Aus": 1280,
+          "Heizungspumpe (siehe Infotaste!)": 1283,
+          "Laing/Lowara Kesselpumpe f\u00fcr PU/PC": 1282,
+          "Pulspaket f\u00fcr NICHT elektronisch geregelte Pumpe": 1281,
+          "Solarpumpe (siehe Infotaste!)": 1284
+        },
+        "value": "Heizungspumpe (siehe Infotaste!)"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_kesselpumpe_zustand": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Kesselpumpe > Zustand",
+        "unit": "",
+        "url": "/40/10021/0/11123/2002",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_luftschieber_anforderung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Luftschieber > Anforderung",
+        "unit": "",
+        "url": "/40/10021/0/11115/2001",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_luftschieber_schlie\u00dft_nach": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Luftschieber > Schlie\u00dft nach",
+        "unit": "",
+        "url": "/40/10021/0/11115/2417",
+        "valid_values": null,
+        "value": "Links"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_luftschieber_zustand": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Luftschieber > Zustand",
+        "unit": "",
+        "url": "/40/10021/0/11115/2002",
+        "valid_values": null,
+        "value": "Fehler"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_saugturbine": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Saugturbine",
+        "unit": "",
+        "url": "/40/10021/0/11042/0",
+        "valid_values": null,
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_saugturbine_anforderung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Saugturbine > Anforderung",
+        "unit": "",
+        "url": "/40/10021/0/11042/2001",
+        "valid_values": null,
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_stokerschnecke_anforderung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Stokerschnecke > Anforderung",
+        "unit": "",
+        "url": "/40/10021/0/11030/2001",
+        "valid_values": null,
+        "value": "Vor"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_stokerschnecke_zustand": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Stokerschnecke > Zustand",
+        "unit": "",
+        "url": "/40/10021/0/11030/2002",
+        "valid_values": null,
+        "value": "Vor"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_umschaltventil": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Umschaltventil",
+        "unit": "",
+        "url": "/40/10021/0/11128/0",
+        "valid_values": null,
+        "value": "Halt"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_umschaltventil_anforderung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Umschaltventil > Anforderung",
+        "unit": "",
+        "url": "/40/10021/0/11128/2001",
+        "valid_values": null,
+        "value": "Halt"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_vorlaufmischer_1_anforderung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Vorlaufmischer 1 > Anforderung",
+        "unit": "",
+        "url": "/40/10021/0/11121/2001",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_vorlaufmischer_1_zustand": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Vorlaufmischer 1 > Zustand",
+        "unit": "",
+        "url": "/40/10021/0/11121/2002",
+        "valid_values": null,
+        "value": "Halt"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_z\u00fcndung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Z\u00fcndung",
+        "unit": "",
+        "url": "/40/10021/0/11041/0",
+        "valid_values": null,
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_z\u00fcndung_anforderung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Ausg\u00e4nge > Z\u00fcndung > Anforderung",
+        "unit": "",
+        "url": "/40/10021/0/11041/2001",
+        "valid_values": null,
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_abgas_sensor_typ": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Abgas > Sensor Typ",
+        "unit": "",
+        "url": "/40/10021/0/11110/2011",
+        "valid_values": {
+          "Analoger Raumf\u00fchler": 1116,
+          "KTY": 1114,
+          "KTY Au\u00dfenf\u00fchler": 1115,
+          "Pt1000": 1111,
+          "Pt1000 Abgasf\u00fchler": 1112,
+          "Pt1000 Au\u00dfenf\u00fchler": 1113
+        },
+        "value": "Pt1000 Abgasf\u00fchler"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_abgas_zustand": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Abgas > Zustand",
+        "unit": "",
+        "url": "/40/10021/0/11110/2002",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_aschebox": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Aschebox",
+        "unit": "",
+        "url": "/40/10021/0/11034/0",
+        "valid_values": null,
+        "value": "Ja"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_aschebox_eingang": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Aschebox > Eingang",
+        "unit": "",
+        "url": "/40/10021/0/11034/2017",
+        "valid_values": {
+          "Invertiert": 3451,
+          "Nicht invertiert": 3450
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_glutbett": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Glutbett",
+        "unit": "",
+        "url": "/40/10021/0/11036/0",
+        "valid_values": null,
+        "value": "OK"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_glutbett_eingang": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Glutbett > Eingang",
+        "unit": "",
+        "url": "/40/10021/0/11036/2017",
+        "valid_values": {
+          "Invertiert": 3451,
+          "Nicht invertiert": 3450
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel_sensor_typ": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel > Sensor Typ",
+        "unit": "",
+        "url": "/40/10021/0/11109/2011",
+        "valid_values": {
+          "Analoger Raumf\u00fchler": 1116,
+          "KTY": 1114,
+          "KTY Au\u00dfenf\u00fchler": 1115,
+          "Pt1000": 1111,
+          "Pt1000 Abgasf\u00fchler": 1112,
+          "Pt1000 Au\u00dfenf\u00fchler": 1113
+        },
+        "value": "Pt1000"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel_unten_sensor_typ": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel unten > Sensor Typ",
+        "unit": "",
+        "url": "/40/10021/0/11122/2011",
+        "valid_values": {
+          "Analoger Raumf\u00fchler": 1116,
+          "KTY": 1114,
+          "KTY Au\u00dfenf\u00fchler": 1115,
+          "Pt1000": 1111,
+          "Pt1000 Abgasf\u00fchler": 1112,
+          "Pt1000 Au\u00dfenf\u00fchler": 1113
+        },
+        "value": "Pt1000"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel_unten_zustand": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel unten > Zustand",
+        "unit": "",
+        "url": "/40/10021/0/11122/2002",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel_vorlauf_1_sensor_typ": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel Vorlauf 1 > Sensor Typ",
+        "unit": "",
+        "url": "/40/10021/0/11058/2011",
+        "valid_values": {
+          "Analoger Raumf\u00fchler": 1116,
+          "KTY": 1114,
+          "KTY Au\u00dfenf\u00fchler": 1115,
+          "Pt1000": 1111,
+          "Pt1000 Abgasf\u00fchler": 1112,
+          "Pt1000 Au\u00dfenf\u00fchler": 1113
+        },
+        "value": "Pt1000"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel_vorlauf_1_zustand": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel Vorlauf 1 > Zustand",
+        "unit": "",
+        "url": "/40/10021/0/11058/2002",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_messblende_versorgung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Messblende > Versorgung",
+        "unit": "",
+        "url": "/40/10021/0/11181/0",
+        "valid_values": null,
+        "value": "Vor"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_messblende_versorgung_anforderung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Messblende > Versorgung > Anforderung",
+        "unit": "",
+        "url": "/40/10021/0/11181/2001",
+        "valid_values": null,
+        "value": "Vor"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_not-aus_schalter": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Not-Aus Schalter",
+        "unit": "",
+        "url": "/40/10021/0/11032/0",
+        "valid_values": null,
+        "value": "OK"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_not-aus_schalter_eingang": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Not-Aus Schalter > Eingang",
+        "unit": "",
+        "url": "/40/10021/0/11032/2017",
+        "valid_values": {
+          "Invertiert": 3451,
+          "Nicht invertiert": 3450
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_pelletsbeh\u00e4lter": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Pelletsbeh\u00e4lter",
+        "unit": "",
+        "url": "/40/10021/0/11037/0",
+        "valid_values": null,
+        "value": "Nicht voll"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_pelletsbeh\u00e4lter_eingang": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Pelletsbeh\u00e4lter > Eingang",
+        "unit": "",
+        "url": "/40/10021/0/11037/2017",
+        "valid_values": {
+          "Invertiert": 3451,
+          "Nicht invertiert": 3450
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_restsauerstoff_anforderung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Restsauerstoff > Anforderung",
+        "unit": "",
+        "url": "/40/10021/0/11108/2001",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_restsauerstoff_kalibrierung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Restsauerstoff > Kalibrierung",
+        "unit": "",
+        "url": "/40/10021/0/0/13944",
+        "valid_values": null,
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_restsauerstoff_sensor_typ": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Restsauerstoff > Sensor Typ",
+        "unit": "",
+        "url": "/40/10021/0/11108/2011",
+        "valid_values": {
+          "HuS 118": 1122,
+          "LSU4": 1121,
+          "NGK ZFAS": 1123
+        },
+        "value": "HuS 118"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_restsauerstoff_zustand": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Restsauerstoff > Zustand",
+        "unit": "",
+        "url": "/40/10021/0/11108/2002",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_rost_geschlossen?": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Rost geschlossen?",
+        "unit": "",
+        "url": "/40/10021/0/0/12251",
+        "valid_values": null,
+        "value": "Ja"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_stb": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > STB",
+        "unit": "",
+        "url": "/40/10021/0/11033/0",
+        "valid_values": null,
+        "value": "OK"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_stb_eingang": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > STB > Eingang",
+        "unit": "",
+        "url": "/40/10021/0/11033/2017",
+        "valid_values": {
+          "Invertiert": 3451,
+          "Nicht invertiert": 3450
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_wassermangel": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Wassermangel",
+        "unit": "",
+        "url": "/40/10021/0/11031/0",
+        "valid_values": null,
+        "value": "OK"
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_wassermangel_eingang": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Wassermangel > Eingang",
+        "unit": "",
+        "url": "/40/10021/0/11031/2017",
+        "valid_values": {
+          "Invertiert": 3451,
+          "Nicht invertiert": 3450
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__kessel_kessel": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel",
+        "unit": "",
+        "url": "/40/10021/0/0/19402",
+        "valid_values": null,
+        "value": "Heizen"
+      },
+      "eta_192_168_0_25__kessel_kessel_abgas_emissionsmessung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel > Abgas > Emissionsmessung",
+        "unit": "",
+        "url": "/40/10021/0/0/13266",
+        "valid_values": null,
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__kessel_kessel_abgas_emissionsmessung_art_der_messung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel > Abgas > Emissionsmessung > Art der Messung",
+        "unit": "",
+        "url": "/40/10021/0/0/12116",
+        "valid_values": {
+          "Kombination": 1962,
+          "Nennlast": 1960,
+          "Teillast": 1961
+        },
+        "value": "Nennlast"
+      },
+      "eta_192_168_0_25__kessel_kessel_abgas_emissionsmessung_jetzt_starten": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel > Abgas > Emissionsmessung > Jetzt starten",
+        "unit": "",
+        "url": "/40/10021/0/0/13269",
+        "valid_values": {
+          "Ja, gleich Messen": 3932,
+          "Ja, zuerst Entaschen": 3931,
+          "Nein": 3930
+        },
+        "value": "Nein"
+      },
+      "eta_192_168_0_25__kessel_kessel_entaschung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel > Entaschung",
+        "unit": "",
+        "url": "/40/10021/0/0/12050",
+        "valid_values": null,
+        "value": "Bereit"
+      },
+      "eta_192_168_0_25__kessel_kessel_erg\u00e4nzung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel > Erg\u00e4nzung",
+        "unit": "",
+        "url": "/40/10021/0/0/19391",
+        "valid_values": null,
+        "value": "0_4200"
+      },
+      "eta_192_168_0_25__kessel_kessel_kessellaufmeldung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel > Kessellaufmeldung",
+        "unit": "",
+        "url": "/40/10021/0/0/14268",
+        "valid_values": null,
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__kessel_kessel_kessellaufmeldung_aktiv_wenn": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel > Kessellaufmeldung > Aktiv wenn",
+        "unit": "",
+        "url": "/40/10021/0/0/13161",
+        "valid_values": {
+          "Abgasgebl\u00e4se ein": 3000,
+          "Brennstofff\u00f6rderung ein": 3001,
+          "Ein/Aus Taste ein": 3002,
+          "Kesselzustand ist Heizen": 3003
+        },
+        "value": "Abgasgebl\u00e4se ein"
+      },
+      "eta_192_168_0_25__kessel_kessel_kessellaufmeldung_laufmeldung_von_schnittstellen": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel > Kessellaufmeldung > Laufmeldung von Schnittstellen",
+        "unit": "",
+        "url": "/40/10021/0/0/14275",
+        "valid_values": null,
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__kessel_kessel_kesselst\u00f6rmeldung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel > Kesselst\u00f6rmeldung",
+        "unit": "",
+        "url": "/40/10021/0/0/14265",
+        "valid_values": null,
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__kessel_kessel_kesselst\u00f6rmeldung_ab_priorit\u00e4t": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel > Kesselst\u00f6rmeldung > ab Priorit\u00e4t",
+        "unit": "",
+        "url": "/40/10021/0/0/13353",
+        "valid_values": {
+          "Fehler": 3252,
+          "Meldung": 3250,
+          "Warnung": 3251
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__kessel_kessel_kesselst\u00f6rmeldung_kesselst\u00f6rmeldung_f\u00fcr_schnittstellen": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel > Kesselst\u00f6rmeldung > Kesselst\u00f6rmeldung f\u00fcr Schnittstellen",
+        "unit": "",
+        "url": "/40/10021/0/0/14267",
+        "valid_values": null,
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__kessel_kessel_pelletsbeh\u00e4lter": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel > Pelletsbeh\u00e4lter",
+        "unit": "",
+        "url": "/40/10021/0/0/12005",
+        "valid_values": null,
+        "value": "Nicht voll"
+      },
+      "eta_192_168_0_25__kessel_kessel_vorlaufregler_1": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel > Vorlaufregler 1",
+        "unit": "",
+        "url": "/40/10021/0/0/12078",
+        "valid_values": null,
+        "value": "Regeln"
+      },
+      "eta_192_168_0_25__kessel_kessel_z\u00fcndung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Kessel > Z\u00fcndung",
+        "unit": "",
+        "url": "/40/10021/0/0/12163",
+        "valid_values": null,
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__kessel_sonstiges_designvariante": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Sonstiges > Designvariante",
+        "unit": "",
+        "url": "/40/10021/0/0/13603",
+        "valid_values": null,
+        "value": "ab 2016"
+      },
+      "eta_192_168_0_25__kessel_sonstiges_kessel": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Kessel > Sonstiges > Kessel",
+        "unit": "",
+        "url": "/40/10021/0/0/12000",
+        "valid_values": null,
+        "value": "Heizen"
+      },
+      "eta_192_168_0_25__lagerum._ausg\u00e4nge_umschalteinheit": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "LagerUm. > Ausg\u00e4nge > Umschalteinheit",
+        "unit": "",
+        "url": "/40/10211/0/11132/0",
+        "valid_values": null,
+        "value": "Halt"
+      },
+      "eta_192_168_0_25__lagerum._ausg\u00e4nge_umschalteinheit_anforderung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "LagerUm. > Ausg\u00e4nge > Umschalteinheit > Anforderung",
+        "unit": "",
+        "url": "/40/10211/0/11132/2001",
+        "valid_values": null,
+        "value": "Halt"
+      },
+      "eta_192_168_0_25__lagerum._ausg\u00e4nge_umschalteinheit_zustand": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "LagerUm. > Ausg\u00e4nge > Umschalteinheit > Zustand",
+        "unit": "",
+        "url": "/40/10211/0/11132/2002",
+        "valid_values": null,
+        "value": "Halt"
+      },
+      "eta_192_168_0_25__lagerum._eing\u00e4nge_nullpunktschalter": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "LagerUm. > Eing\u00e4nge > Nullpunktschalter",
+        "unit": "",
+        "url": "/40/10211/0/11133/0",
+        "valid_values": null,
+        "value": "Aus"
+      },
+      "eta_192_168_0_25__lagerum._eing\u00e4nge_nullpunktschalter_eingang": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "LagerUm. > Eing\u00e4nge > Nullpunktschalter > Eingang",
+        "unit": "",
+        "url": "/40/10211/0/11133/2017",
+        "valid_values": {
+          "Invertiert": 3451,
+          "Nicht invertiert": 3450
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__lagerum._eing\u00e4nge_positionsschalter": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "LagerUm. > Eing\u00e4nge > Positionsschalter",
+        "unit": "",
+        "url": "/40/10211/0/0/12266",
+        "valid_values": null,
+        "value": "Ja"
+      },
+      "eta_192_168_0_25__lagerum._sonstiges_austragung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "LagerUm. > Sonstiges > Austragung",
+        "unit": "",
+        "url": "/40/10211/0/0/12058",
+        "valid_values": null,
+        "value": "Bereit"
+      },
+      "eta_192_168_0_25__lagerum._sonstiges_position_1": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "LagerUm. > Sonstiges > Position 1",
+        "unit": "",
+        "url": "/40/10211/0/0/12262",
+        "valid_values": {
+          "Frei": 1804,
+          "Gesperrt": 1805
+        },
+        "value": "Frei"
+      },
+      "eta_192_168_0_25__lagerum._sonstiges_position_2": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "LagerUm. > Sonstiges > Position 2",
+        "unit": "",
+        "url": "/40/10211/0/0/12263",
+        "valid_values": {
+          "Frei": 1804,
+          "Gesperrt": 1805
+        },
+        "value": "Frei"
+      },
+      "eta_192_168_0_25__lagerum._sonstiges_position_3": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "LagerUm. > Sonstiges > Position 3",
+        "unit": "",
+        "url": "/40/10211/0/0/12264",
+        "valid_values": {
+          "Frei": 1804,
+          "Gesperrt": 1805
+        },
+        "value": "Frei"
+      },
+      "eta_192_168_0_25__lagerum._sonstiges_position_4": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "LagerUm. > Sonstiges > Position 4",
+        "unit": "",
+        "url": "/40/10211/0/0/12539",
+        "valid_values": {
+          "Frei": 1804,
+          "Gesperrt": 1805
+        },
+        "value": "Frei"
+      },
+      "eta_192_168_0_25__lagerum._sonstiges_position_5": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "LagerUm. > Sonstiges > Position 5",
+        "unit": "",
+        "url": "/40/10211/0/0/12879",
+        "valid_values": {
+          "Frei": 1804,
+          "Gesperrt": 1805
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__lagerum._sonstiges_position_6": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "LagerUm. > Sonstiges > Position 6",
+        "unit": "",
+        "url": "/40/10211/0/0/12880",
+        "valid_values": {
+          "Frei": 1804,
+          "Gesperrt": 1805
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__lagerum._sonstiges_position_7": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "LagerUm. > Sonstiges > Position 7",
+        "unit": "",
+        "url": "/40/10211/0/0/12881",
+        "valid_values": {
+          "Frei": 1804,
+          "Gesperrt": 1805
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__lagerum._sonstiges_position_8": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "LagerUm. > Sonstiges > Position 8",
+        "unit": "",
+        "url": "/40/10211/0/0/12882",
+        "valid_values": {
+          "Frei": 1804,
+          "Gesperrt": 1805
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__lagerum._typ_der_umschalteinheit": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "LagerUm. > Typ der Umschalteinheit",
+        "unit": "",
+        "url": "/40/10211/0/0/13986",
+        "valid_values": {
+          "3-fach": 6001,
+          "4-fach": 6002,
+          "8-fach drehend": 6004,
+          "8-fach linear": 6003
+        },
+        "value": "4-fach"
+      },
+      "eta_192_168_0_25__sys_antiblockierschutz_an_welchem_tag?": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Sys > Antiblockierschutz > an welchem Tag?",
+        "unit": "",
+        "url": "/120/10241/0/0/14243",
+        "valid_values": {
+          "Dienstag": 6352,
+          "Donnerstag": 6354,
+          "Freitag": 6355,
+          "Mittwoch": 6353,
+          "Montag": 6351,
+          "Samstag": 6356,
+          "Sonntag": 6350
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__sys_antiblockierschutz_zeitpunkt": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Sys > Antiblockierschutz > Zeitpunkt",
+        "unit": "",
+        "url": "/120/10241/0/0/14242",
+        "valid_values": {
+          "einstellbar": 6361,
+          "fix": 6360
+        },
+        "value": "fix"
+      },
+      "eta_192_168_0_25__sys_au\u00dfentemperatur_au\u00dfentemperaturf\u00fchler_sensor_typ": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Sys > Au\u00dfentemperatur > Au\u00dfentemperaturf\u00fchler > Sensor Typ",
+        "unit": "",
+        "url": "/120/10241/0/11127/2011",
+        "valid_values": {
+          "Analoger Raumf\u00fchler": 1116,
+          "KTY": 1114,
+          "KTY Au\u00dfenf\u00fchler": 1115,
+          "Pt1000": 1111,
+          "Pt1000 Abgasf\u00fchler": 1112,
+          "Pt1000 Au\u00dfenf\u00fchler": 1113
+        },
+        "value": "Pt1000 Au\u00dfenf\u00fchler"
+      },
+      "eta_192_168_0_25__sys_au\u00dfentemperatur_au\u00dfentemperaturf\u00fchler_zustand": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Sys > Au\u00dfentemperatur > Au\u00dfentemperaturf\u00fchler > Zustand",
+        "unit": "",
+        "url": "/120/10241/0/11127/2002",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__sys_externe_st\u00f6rmeldung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Sys > Externe St\u00f6rmeldung",
+        "unit": "",
+        "url": "/120/10241/0/0/14259",
+        "valid_values": null,
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__sys_externe_st\u00f6rmeldung_externe_st\u00f6rmeldung_von_schnittstellen": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Sys > Externe St\u00f6rmeldung > Externe St\u00f6rmeldung von Schnittstellen",
+        "unit": "",
+        "url": "/120/10241/0/0/14261",
+        "valid_values": {
+          "Fehler": 1050,
+          "OK": 1051
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__sys_st\u00f6rmeldung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Sys > St\u00f6rmeldung",
+        "unit": "",
+        "url": "/120/10241/0/0/14262",
+        "valid_values": null,
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__sys_st\u00f6rmeldung_ab_priorit\u00e4t": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Sys > St\u00f6rmeldung > ab Priorit\u00e4t",
+        "unit": "",
+        "url": "/120/10241/0/0/13353",
+        "valid_values": {
+          "Alarm": 3253,
+          "Fehler": 3252,
+          "Meldung": 3250,
+          "Warnung": 3251
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__sys_st\u00f6rmeldung_st\u00f6rmeldung_f\u00fcr_schnittstellen": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "Sys > St\u00f6rmeldung > St\u00f6rmeldung f\u00fcr Schnittstellen",
+        "unit": "",
+        "url": "/120/10241/0/0/14264",
+        "valid_values": null,
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__ww_eing\u00e4nge_warmwasserspeicher_sensor_typ": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "WW > Eing\u00e4nge > Warmwasserspeicher > Sensor Typ",
+        "unit": "",
+        "url": "/120/10111/0/11129/2011",
+        "valid_values": {
+          "Analoger Raumf\u00fchler": 1116,
+          "KTY": 1114,
+          "KTY Au\u00dfenf\u00fchler": 1115,
+          "Pt1000": 1111,
+          "Pt1000 Abgasf\u00fchler": 1112,
+          "Pt1000 Au\u00dfenf\u00fchler": 1113
+        },
+        "value": "Pt1000"
+      },
+      "eta_192_168_0_25__ww_eing\u00e4nge_warmwasserspeicher_zustand": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "WW > Eing\u00e4nge > Warmwasserspeicher > Zustand",
+        "unit": "",
+        "url": "/120/10111/0/11129/2002",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__ww_sonstiges_warmwasserspeicher": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "WW > Sonstiges > Warmwasserspeicher",
+        "unit": "",
+        "url": "/120/10111/0/0/12129",
+        "valid_values": null,
+        "value": "Geladen"
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "WW > Warmwasserspeicher",
+        "unit": "",
+        "url": "/120/10111/0/0/19406",
+        "valid_values": null,
+        "value": "Geladen"
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_erg\u00e4nzung": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "WW > Warmwasserspeicher > Erg\u00e4nzung",
+        "unit": "",
+        "url": "/120/10111/0/0/19391",
+        "valid_values": null,
+        "value": "0_4080"
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_laden_mit_erzeuger": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "WW > Warmwasserspeicher > Laden mit Erzeuger",
+        "unit": "",
+        "url": "/120/10111/0/0/12932",
+        "valid_values": {
+          "Nein": 6530,
+          "mit jedem Erzeuger": 6531,
+          "nicht mit Brenner": 6533,
+          "nur mit St\u00fcckholzkessel": 6532
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten",
+        "unit": "",
+        "url": "/120/10111/12130/0/0",
+        "valid_values": null,
+        "value": "Ein"
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_schaltzustand": {
+        "endpoint_type": "TEXT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Schaltzustand",
+        "unit": "",
+        "url": "/120/10111/12130/0/1109",
+        "valid_values": null,
+        "value": "Ein"
+      }
+    },
+    "WRITABLE_DICT": {
+      "eta_192_168_0_25__fbh_eing\u00e4nge_vorlauf_fixwert_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Eing\u00e4nge > Vorlauf > Fixwert",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/11060/2054",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__fbh_eing\u00e4nge_vorlauf_kalibrierwert_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Eing\u00e4nge > Vorlauf > Kalibrierwert",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/11060/2049",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 5.0,
+          "scaled_min_value": -5.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_anforderungsdifferenz_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Anforderungsdifferenz",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12109",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 50.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 3.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_estrich_absenkung_um_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Estrich > Absenkung um",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12309",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 20.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 3.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_estrich_anstieg_um_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Estrich > Anstieg um",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12305",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 20.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 3.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_estrich_erneute_max._temperatur_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Estrich > erneute Max. Temperatur",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/14688",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 60.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_estrich_max._temperatur_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Estrich > Max. Temperatur",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12307",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 60.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 40.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_estrich_vorlauf_soll_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Estrich > Vorlauf Soll",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12304",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 60.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 15.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizgrenze_f\u00fcr_'absenken'_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizgrenze f\u00fcr 'Absenken'",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12097",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 50.0,
+          "scaled_min_value": -50.0
+        },
+        "value": 2.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizgrenze_f\u00fcr_'heizen'_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizgrenze f\u00fcr 'Heizen'",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/14116",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 50.0,
+          "scaled_min_value": -50.0
+        },
+        "value": 22.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizkreispumpe_pumpendrehzahl_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizkreispumpe > Pumpendrehzahl",
+        "unit": "%",
+        "url": "/120/10102/0/0/12258",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 10.0
+        },
+        "value": 60.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizkurve_aus_bei_heizkurve_unter_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizkurve > Aus bei Heizkurve unter",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/14133",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 50.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 22.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizkurve_schieber_position_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizkurve > Schieber Position",
+        "unit": "%",
+        "url": "/120/10102/0/0/12240",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": -100.0
+        },
+        "value": 50.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizkurve_vorlauf_absenkung_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizkurve > Vorlauf Absenkung",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12107",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 50.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 3.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizkurve_vorlauf_bei_+10\u00b0c_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizkurve > Vorlauf bei +10\u00b0C",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12103",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 25.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_heizkurve_vorlauf_bei_-10\u00b0c_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Heizkurve > Vorlauf bei -10\u00b0C",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12104",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 33.0
+      },
+      "eta_192_168_0_25__fbh_heizkreis_vorlauf_vorlauf_max_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Fbh > Heizkreis > Vorlauf > Vorlauf Max",
+        "unit": "\u00b0C",
+        "url": "/120/10102/0/0/12108",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 45.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_estrich_absenkung_um_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Estrich > Absenkung um",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12309",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 20.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 3.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_estrich_anstieg_um_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Estrich > Anstieg um",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12305",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 20.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 3.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_estrich_erneute_max._temperatur_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Estrich > erneute Max. Temperatur",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/14688",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 60.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_estrich_max._temperatur_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Estrich > Max. Temperatur",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12307",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 60.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 40.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_estrich_vorlauf_soll_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Estrich > Vorlauf Soll",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12304",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 60.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 15.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizgrenze_f\u00fcr_'absenken'_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizgrenze f\u00fcr 'Absenken'",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12097",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 50.0,
+          "scaled_min_value": -50.0
+        },
+        "value": 2.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizgrenze_f\u00fcr_'heizen'_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizgrenze f\u00fcr 'Heizen'",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/14116",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 50.0,
+          "scaled_min_value": -50.0
+        },
+        "value": 21.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizkurve_aus_bei_heizkurve_unter_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizkurve > Aus bei Heizkurve unter",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/14133",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 50.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 22.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizkurve_schieber_position_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizkurve > Schieber Position",
+        "unit": "%",
+        "url": "/120/10101/0/0/12240",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": -100.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizkurve_vorlauf_absenkung_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizkurve > Vorlauf Absenkung",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12107",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 50.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 3.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizkurve_vorlauf_bei_+10\u00b0c_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizkurve > Vorlauf bei +10\u00b0C",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12103",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 25.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_heizkurve_vorlauf_bei_-10\u00b0c_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Heizkurve > Vorlauf bei -10\u00b0C",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12104",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 33.0
+      },
+      "eta_192_168_0_25__hk_heizkreis_vorlauf_vorlauf_max_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "HK > Heizkreis > Vorlauf > Vorlauf Max",
+        "unit": "\u00b0C",
+        "url": "/120/10101/0/0/12108",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 45.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_abgas_fixwert_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Abgas > Fixwert",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11110/2054",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 200.0,
+          "scaled_min_value": -100.0
+        },
+        "value": 120.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_abgas_kalibrierwert_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Abgas > Kalibrierwert",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11110/2049",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 5.0,
+          "scaled_min_value": -5.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel_fixwert_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel > Fixwert",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11109/2054",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 200.0,
+          "scaled_min_value": -100.0
+        },
+        "value": 70.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel_kalibrierwert_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel > Kalibrierwert",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11109/2049",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 5.0,
+          "scaled_min_value": -5.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel_unten_fixwert_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel unten > Fixwert",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11122/2054",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 200.0,
+          "scaled_min_value": -100.0
+        },
+        "value": 55.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel_unten_kalibrierwert_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel unten > Kalibrierwert",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11122/2049",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 5.0,
+          "scaled_min_value": -5.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel_vorlauf_1_fixwert_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel Vorlauf 1 > Fixwert",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11058/2054",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 200.0,
+          "scaled_min_value": -100.0
+        },
+        "value": 60.0
+      },
+      "eta_192_168_0_25__kessel_eing\u00e4nge_kessel_vorlauf_1_kalibrierwert_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Eing\u00e4nge > Kessel Vorlauf 1 > Kalibrierwert",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/11058/2049",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 5.0,
+          "scaled_min_value": -5.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__kessel_kessel_abgas_abgas_max_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Abgas > Abgas Max",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/0/12023",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 300.0,
+          "scaled_min_value": 100.0
+        },
+        "value": 180.0
+      },
+      "eta_192_168_0_25__kessel_kessel_entaschung_aschebox_leeren_nach_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Entaschung > Aschebox leeren nach",
+        "unit": "kg",
+        "url": "/40/10021/0/0/12120",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 5000.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 1000.0
+      },
+      "eta_192_168_0_25__kessel_kessel_entaschung_beginn_ruhezeit_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Entaschung > Beginn Ruhezeit",
+        "unit": "minutes_since_midnight",
+        "url": "/40/10021/0/0/12248",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 1,
+          "scaled_max_value": 1439.0,
+          "scaled_min_value": 0.0
+        },
+        "value": "21:00"
+      },
+      "eta_192_168_0_25__kessel_kessel_entaschung_entaschen_nach_max._writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Entaschung > Entaschen nach max.",
+        "unit": "kg",
+        "url": "/40/10021/0/0/12074",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 25.0
+      },
+      "eta_192_168_0_25__kessel_kessel_entaschung_entaschen_nach_min._writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Entaschung > Entaschen nach min.",
+        "unit": "kg",
+        "url": "/40/10021/0/0/12073",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 15.0
+      },
+      "eta_192_168_0_25__kessel_kessel_kessel_ausschaltdifferenz_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Kessel > Ausschaltdifferenz",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/0/12141",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 40.0,
+          "scaled_min_value": 3.0
+        },
+        "value": 15.0
+      },
+      "eta_192_168_0_25__kessel_kessel_kessel_kessel_min_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Kessel > Kessel Min",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/0/12022",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 50.0
+        },
+        "value": 55.0
+      },
+      "eta_192_168_0_25__kessel_kessel_kesselpumpe_maximal_drehzahl_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Kesselpumpe > Maximal Drehzahl",
+        "unit": "%",
+        "url": "/40/10021/0/0/12368",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 10.0
+        },
+        "value": 100.0
+      },
+      "eta_192_168_0_25__kessel_kessel_kesselpumpe_mindest_drehzahl_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Kesselpumpe > Mindest Drehzahl",
+        "unit": "%",
+        "url": "/40/10021/0/0/12227",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 10.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__kessel_kessel_pelletsbeh\u00e4lter_saugzeitpunkt_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Pelletsbeh\u00e4lter > Saugzeitpunkt",
+        "unit": "minutes_since_midnight",
+        "url": "/40/10021/0/0/12152",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 1,
+          "scaled_max_value": 1439.0,
+          "scaled_min_value": 0.0
+        },
+        "value": "19:00"
+      },
+      "eta_192_168_0_25__kessel_kessel_restsauerstoff_o2_soll_lin_x1_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Restsauerstoff > O2 Soll > Lin x1",
+        "unit": "%",
+        "url": "/40/10021/12004/0/1051",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 30.0,
+          "scaled_min_value": 30.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__kessel_kessel_restsauerstoff_o2_soll_lin_x2_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Restsauerstoff > O2 Soll > Lin x2",
+        "unit": "%",
+        "url": "/40/10021/12004/0/1053",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 100.0
+        },
+        "value": 100.0
+      },
+      "eta_192_168_0_25__kessel_kessel_restsauerstoff_o2_soll_lin_y1_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Restsauerstoff > O2 Soll > Lin y1",
+        "unit": "%",
+        "url": "/40/10021/12004/0/1052",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 100,
+          "scaled_max_value": 15.0,
+          "scaled_min_value": 7.0
+        },
+        "value": 9.5
+      },
+      "eta_192_168_0_25__kessel_kessel_restsauerstoff_o2_soll_lin_y2_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Restsauerstoff > O2 Soll > Lin y2",
+        "unit": "%",
+        "url": "/40/10021/12004/0/1054",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 100,
+          "scaled_max_value": 15.0,
+          "scaled_min_value": 6.0
+        },
+        "value": 7.0
+      },
+      "eta_192_168_0_25__kessel_kessel_vorlaufregler_1_anforderungsdifferenz_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Kessel > Vorlaufregler 1 > Anforderungsdifferenz",
+        "unit": "\u00b0C",
+        "url": "/40/10021/0/0/12020",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 20.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 5.0
+      },
+      "eta_192_168_0_25__kessel_z\u00e4hlerst\u00e4nde_inhalt_pelletsbeh\u00e4lter_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Kessel > Z\u00e4hlerst\u00e4nde > Inhalt Pelletsbeh\u00e4lter",
+        "unit": "kg",
+        "url": "/40/10021/0/0/12011",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 0.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 28.8
+      },
+      "eta_192_168_0_25__lagerum._vorrat_vorrat_warngrenze_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "LagerUm. > Vorrat > Vorrat Warngrenze",
+        "unit": "kg",
+        "url": "/40/10211/0/0/12042",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100000.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 1000.0
+      },
+      "eta_192_168_0_25__lagerum._vorrat_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "LagerUm. > Vorrat",
+        "unit": "kg",
+        "url": "/40/10211/0/0/12015",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100000.0,
+          "scaled_min_value": -100000.0
+        },
+        "value": 2728.9
+      },
+      "eta_192_168_0_25__sys_antiblockierschutz_zu_welcher_uhrzeit?_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Sys > Antiblockierschutz > zu welcher Uhrzeit?",
+        "unit": "minutes_since_midnight",
+        "url": "/120/10241/0/0/14244",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 1,
+          "scaled_max_value": 1439.0,
+          "scaled_min_value": 0.0
+        },
+        "value": "xxx"
+      },
+      "eta_192_168_0_25__sys_au\u00dfentemperatur_au\u00dfentemperaturf\u00fchler_fixwert_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Sys > Au\u00dfentemperatur > Au\u00dfentemperaturf\u00fchler > Fixwert",
+        "unit": "\u00b0C",
+        "url": "/120/10241/0/11127/2054",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 200.0,
+          "scaled_min_value": -100.0
+        },
+        "value": -5.0
+      },
+      "eta_192_168_0_25__sys_au\u00dfentemperatur_au\u00dfentemperaturf\u00fchler_kalibrierwert_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "Sys > Au\u00dfentemperatur > Au\u00dfentemperaturf\u00fchler > Kalibrierwert",
+        "unit": "\u00b0C",
+        "url": "/120/10241/0/11127/2049",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 5.0,
+          "scaled_min_value": -5.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_eing\u00e4nge_warmwasserspeicher_fixwert_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Eing\u00e4nge > Warmwasserspeicher > Fixwert",
+        "unit": "\u00b0C",
+        "url": "/120/10111/0/11129/2054",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 200.0,
+          "scaled_min_value": -100.0
+        },
+        "value": 53.0
+      },
+      "eta_192_168_0_25__ww_eing\u00e4nge_warmwasserspeicher_kalibrierwert_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Eing\u00e4nge > Warmwasserspeicher > Kalibrierwert",
+        "unit": "\u00b0C",
+        "url": "/120/10111/0/11129/2049",
+        "valid_values": {
+          "dec_places": 1,
+          "scale_factor": 10,
+          "scaled_max_value": 5.0,
+          "scaled_min_value": -5.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_einschaltdifferenz_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Einschaltdifferenz",
+        "unit": "\u00b0C",
+        "url": "/120/10111/0/0/12133",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 30.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 20.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_laden_mit_anderen_verbrauchern_einschaltdifferenz_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Laden mit anderen Verbrauchern > Einschaltdifferenz",
+        "unit": "\u00b0C",
+        "url": "/120/10111/0/0/13535",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 30.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 5.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_dienstag_wert_au\u00dferhalb_der_zeitfenster_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Dienstag > Wert au\u00dferhalb der Zeitfenster",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1112",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_donnerstag_wert_au\u00dferhalb_der_zeitfenster_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Donnerstag > Wert au\u00dferhalb der Zeitfenster",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1114",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_freitag_wert_au\u00dferhalb_der_zeitfenster_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Freitag > Wert au\u00dferhalb der Zeitfenster",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1115",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_mittwoch_wert_au\u00dferhalb_der_zeitfenster_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Mittwoch > Wert au\u00dferhalb der Zeitfenster",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1113",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_montag_wert_au\u00dferhalb_der_zeitfenster_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Montag > Wert au\u00dferhalb der Zeitfenster",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1111",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_samstag_wert_au\u00dferhalb_der_zeitfenster_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Samstag > Wert au\u00dferhalb der Zeitfenster",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1116",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_ladezeiten_sonntag_wert_au\u00dferhalb_der_zeitfenster_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Ladezeiten > Sonntag > Wert au\u00dferhalb der Zeitfenster",
+        "unit": "\u00b0C",
+        "url": "/120/10111/12130/0/1117",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 30.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_solltemperatur_f\u00fcr_'sofort_laden'_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Solltemperatur f\u00fcr 'Sofort laden'",
+        "unit": "\u00b0C",
+        "url": "/120/10111/0/0/14257",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 50.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_temperaturwarnung_1_differenz_warnung_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Temperaturwarnung 1 > Differenz Warnung",
+        "unit": "\u00b0C",
+        "url": "/120/10111/0/0/13039",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 80.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 0.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_warmwasserspeicher_max._writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Warmwasserspeicher max.",
+        "unit": "\u00b0C",
+        "url": "/120/10111/0/0/12169",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 100.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 75.0
+      },
+      "eta_192_168_0_25__ww_warmwasserspeicher_warmwasserspeicher_soll_writable": {
+        "endpoint_type": "DEFAULT",
+        "friendly_name": "WW > Warmwasserspeicher > Warmwasserspeicher Soll",
+        "unit": "\u00b0C",
+        "url": "/120/10111/0/0/12132",
+        "valid_values": {
+          "dec_places": 0,
+          "scale_factor": 10,
+          "scaled_max_value": 90.0,
+          "scaled_min_value": 0.0
+        },
+        "value": 55.0
+      }
+    },
+    "chosen_float_sensors": [
+      "eta_192_168_0_25__kessel_kessel_pelletsbeh\u00e4lter_saugzeitpunkt",
+      "eta_192_168_0_25__sys_au\u00dfentemperatur",
+      "eta_192_168_0_25__kessel_kessel_abgas",
+      "eta_192_168_0_25__kessel_ausg\u00e4nge_vorlaufmischer_1"
+    ],
+    "chosen_switches": [
+      "eta_192_168_0_25__kessel_sonstiges_ein/aus_taste"
+    ],
+    "chosen_text_sensors": [
+      "eta_192_168_0_25__kessel_kessel"
+    ],
+    "chosen_writable_sensors": [
+      "eta_192_168_0_25__kessel_kessel_pelletsbeh\u00e4lter_saugzeitpunkt_writable",
+      "eta_192_168_0_25__fbh_eing\u00e4nge_vorlauf_fixwert_writable"
+    ],
+    "force_legacy_mode": false,
+    "host": "192.168.0.25",
+    "ignore_decimal_places_restriction_for_writable_entities": [],
+    "port": "9091"
+  }
+}


### PR DESCRIPTION
- Move sensors with custom units from float entities to text entities
    - Currently this only applies to sensors with the unit `minutes_since_midnight`, e.g. Saugzeitpunkt
- Added tests to check migration behaviour

Related to #40