### PR TITLE
Fix incorrect boundary check for writable entities

### DIFF
--- a/custom_components/eta_webservices/number.py
+++ b/custom_components/eta_webservices/number.py
@@ -130,8 +130,8 @@ class EtaWritableNumberSensor(NumberEntity, EtaWritableSensorEntity):
             raw_value *= self.valid_values["scale_factor"]
             raw_value = round(raw_value, 0)
             if (
-                raw_value < self.valid_values["scaled_min_value"]
-                or raw_value > self.valid_values["scaled_max_value"]
+                value < self.valid_values["scaled_min_value"]
+                or value > self.valid_values["scaled_max_value"]
             ):
                 raise HomeAssistantError(
                     f"Temperature value out of bounds for entity {self.entity_id}"


### PR DESCRIPTION
### Fix incorrect boundary handling for writable ETA values

After ETA firmware update x.64.x the integration could no longer set values
like -100…+100 for writable entities (e.g. Heizkreis → Heizkurve → Schieber Position).

The ETA API now reports:
- scaleFactor = 10
- decPlaces = 0
- raw range = -1000 … +1000

However, the integration used `decPlaces` to validate boundaries.
Because `decPlaces` is 0, values were effectively restricted to -10…+10.

Example from API:
100%  -> raw 1000 (scaleFactor=10)
-100% -> raw -1000 (scaleFactor=10)

The correct calculation should be based on `scaleFactor`, not `decPlaces`.

This PR adjusts the boundary handling to use `scaleFactor` for writable
number entities so that the full valid range (-100…+100) works again.

Tested locally in Home Assistant:
- Setting -100, 0, +100 works
- Values are correctly converted to raw form
