### PR TITLE
fix(discovery): keep numeric unit on transient invalid ETA values

### DIFF
--- a/custom_components/eta_webservices/_api/sensor_discovery_v12.py
+++ b/custom_components/eta_webservices/_api/sensor_discovery_v12.py
@@ -21,6 +21,22 @@ _LOGGER = logging.getLogger(__name__)
 class SensorDiscoveryV12(SensorDiscoveryBase):
     """ETA API v1.2 specific sensor discovery implementation."""
 
+    @staticmethod
+    def _is_numeric_value(value: float | str) -> bool:
+        """Return True if a value can be interpreted as a number."""
+        if isinstance(value, bool):
+            return False
+        if isinstance(value, (int, float)):
+            return True
+        normalized_value = str(value).strip().replace(",", ".")
+        if normalized_value == "":
+            return False
+        try:
+            float(normalized_value)
+        except ValueError:
+            return False
+        return True
+
     def _is_switch(
         self, endpoint_info: ETAEndpoint, raw_value: str | None = None
     ) -> bool:
@@ -499,18 +515,38 @@ class SensorDiscoveryV12(SensorDiscoveryBase):
 
                     value, unit = data_result
                     endpoint_info["value"] = value
+                    previous_unit = endpoint_info["unit"]
+
+                    # Preserve a previously known non-empty unit when the current
+                    # value response is transient/non-numeric and reports no unit.
+                    # ETA endpoints like Restsauerstoff can temporarily return
+                    # strValue="---" and unit="", which must not drop the sensor.
+                    keep_previous_unit = (
+                        previous_unit not in CUSTOM_UNITS
+                        and previous_unit != ""
+                        and unit == ""
+                        and not self._is_numeric_value(value)
+                    )
                     if (
-                        unit != endpoint_info["unit"]
-                        and endpoint_info["unit"] not in CUSTOM_UNITS
+                        not keep_previous_unit
+                        and unit != previous_unit
+                        and previous_unit not in CUSTOM_UNITS
                         # update the unit of the sensor if they are different, but only if we didn't assign a custom unit to the sensor
                     ):
                         _LOGGER.debug(
                             "Correcting unit for sensor %s from '%s' to '%s'",
                             unique_key,
-                            endpoint_info["unit"],
+                            previous_unit,
                             unit,
                         )
                         endpoint_info["unit"] = unit
+                    elif keep_previous_unit:
+                        _LOGGER.debug(
+                            "Keeping previous unit '%s' for sensor %s because ETA returned transient value '%s' with empty unit",
+                            previous_unit,
+                            unique_key,
+                            value,
+                        )
                     if (
                         endpoint_info["endpoint_type"] == "DEFAULT"
                         and endpoint_info["unit"] == ""

--- a/tests/custom_components/eta_webservices/test_api.py
+++ b/tests/custom_components/eta_webservices/test_api.py
@@ -406,6 +406,73 @@ async def test_get_all_sensors_v12_handles_exceptions():
 
 
 @pytest.mark.asyncio
+async def test_get_all_sensors_v12_keeps_varinfo_unit_on_transient_invalid_value():
+    """Keep v1.2 varinfo unit if var temporarily returns empty unit + non-numeric value."""
+    mock_session = AsyncMock(spec=ClientSession)
+    api = EtaAPI(mock_session, "192.168.0.25", 8080)
+
+    api.is_correct_api_version = AsyncMock(return_value=True)
+
+    menu_xml = (
+        '<?xml version="1.0" encoding="utf-8"?>'
+        '<eta version="1.0" xmlns="http://www.eta.co.at/rest/v1">'
+        '<menu><fub uri="/40/10021" name="Kessel">'
+        '<object uri="/40/10021/0/11108/0" name="Restsauerstoff"/>'
+        "</fub></menu></eta>"
+    )
+    varinfo_xml = (
+        '<?xml version="1.0" encoding="utf-8"?>'
+        '<eta version="1.0" xmlns="http://www.eta.co.at/rest/v1">'
+        '<varInfo uri="/user/varinfo/40/10021/0/11108/0">'
+        '<variable uri="40/10021/0/11108/0" name="Restsauerstoff" '
+        'fullName="Kessel > Kessel > Restsauerstoff" unit="%" decPlaces="1" '
+        'scaleFactor="100" advTextOffset="0">'
+        "<type>DEFAULT</type>"
+        "</variable></varInfo></eta>"
+    )
+    var_xml_invalid = (
+        '<?xml version="1.0" encoding="utf-8"?>'
+        '<eta version="1.0" xmlns="http://www.eta.co.at/rest/v1">'
+        '<value uri="/user/var/40/10021/0/11108/0" strValue="---" '
+        'unit="" decPlaces="1" scaleFactor="100" advTextOffset="0">0</value>'
+        "</eta>"
+    )
+
+    async def mock_get_request(suffix):
+        response = AsyncMock()
+        if suffix == "/user/menu":
+            response.text = AsyncMock(return_value=menu_xml)
+        elif "/user/varinfo/" in suffix:
+            response.text = AsyncMock(return_value=varinfo_xml)
+        elif "/user/var/" in suffix:
+            response.text = AsyncMock(return_value=var_xml_invalid)
+        else:
+            response.text = AsyncMock(
+                return_value='<?xml version="1.0" encoding="utf-8"?><eta version="1.0"></eta>'
+            )
+        return response
+
+    api._http.get_request = mock_get_request
+
+    float_dict = {}
+    switches_dict = {}
+    text_dict = {}
+    writable_dict = {}
+
+    await api.get_all_sensors(False, float_dict, switches_dict, text_dict, writable_dict)
+
+    assert len(float_dict) > 0
+    matching_sensors = [
+        sensor
+        for sensor in float_dict.values()
+        if sensor["url"] == "/40/10021/0/11108/0"
+    ]
+    assert matching_sensors, "Expected Restsauerstoff endpoint to be discovered"
+    assert matching_sensors[0]["unit"] == "%"
+    assert matching_sensors[0]["value"] == "---"
+
+
+@pytest.mark.asyncio
 async def test_get_all_sensors_v12_skips_duplicates(load_fixture):
     """Test that get_all_sensors (v1.2) skips duplicate endpoints.
 


### PR DESCRIPTION
## Summary

Fixes a v1.2 discovery edge case where numeric sensors (e.g. Restsauerstoff) could be dropped if ETA temporarily returns a non-numeric placeholder value with empty unit during discovery.

## What changed

- In `sensor_discovery_v12`, keep the previously known non-empty varinfo unit if:
  - runtime `var` response returns empty unit, and
  - value is transient non-numeric (e.g. `---`), and
  - endpoint is not a custom-unit endpoint.
- This prevents endpoints from being reclassified as unknown type and skipped.
- Added regression test for this exact scenario.

## Why

Some ETA endpoints are stable numeric sensors but intermittently return invalid placeholder values when the boiler is not actively running. Discovery should remain robust and not lose these sensors.

## Testing

- `./.venv312/bin/pytest tests/custom_components/eta_webservices/test_api.py -q`
- `./.venv312/bin/pytest tests/custom_components/eta_webservices -q`

## Notes

This change is intentionally limited to discovery classification behavior and does not change runtime polling/write logic.
