### PR TITLE
Refactor coordinator handling

### DIFF
--- a/custom_components/eta_webservices/coordinator.py
+++ b/custom_components/eta_webservices/coordinator.py
@@ -271,7 +271,7 @@ class ETASensorUpdateCoordinator(DataUpdateCoordinator[dict[str, float | str | b
         return data
 
 
-class ETAWritableUpdateCoordinator(DataUpdateCoordinator[dict]):
+class ETAWritableUpdateCoordinator(DataUpdateCoordinator[dict[str, float | str]]):
     """Class to manage fetching data from the ETA terminal."""
 
     def __init__(self, hass: HomeAssistant, config: dict) -> None:
@@ -306,7 +306,7 @@ class ETAWritableUpdateCoordinator(DataUpdateCoordinator[dict]):
     def _should_force_number_handling(self, unit):
         return unit == CUSTOM_UNIT_MINUTES_SINCE_MIDNIGHT
 
-    async def _async_update_data(self) -> dict:
+    async def _async_update_data(self) -> dict[str, float | str]:
         """Update data via library."""
         if (
             (
@@ -325,11 +325,7 @@ class ETAWritableUpdateCoordinator(DataUpdateCoordinator[dict]):
 
         eta_client = self._create_eta_client()
         sensor_list = {
-            self.all_writable_sensors[sensor]["url"]: {
-                "force_number_handling": self._should_force_number_handling(
-                    self.all_writable_sensors[sensor]["unit"]
-                )
-            }
+            self.all_writable_sensors[sensor]["url"]: {}
             for sensor in self.chosen_writable_sensors
         }
 

--- a/custom_components/eta_webservices/coordinator.py
+++ b/custom_components/eta_webservices/coordinator.py
@@ -239,26 +239,21 @@ class ETASensorUpdateCoordinator(DataUpdateCoordinator[dict[str, float | str | b
 
         async with timeout(REQUEST_TIMEOUT):
             if uri_sensor_queries:
-                all_sensor_data = await eta_client.get_all_data(uri_sensor_queries)
-                for sensor, (uri, _) in self.sensor_queries.items():
-                    result = all_sensor_data.get(uri)
-                    if result is None:
-                        continue
-                    data[sensor] = result
+                data = await eta_client.get_all_data(uri_sensor_queries)
 
             if self.switch_queries:
                 unique_switch_uris = list(
-                    # Query shared switch URIs once and map results back per entity.
+                    # Query shared switch URIs only once
                     dict.fromkeys([uri for uri, _, _ in self.switch_queries.values()])
                 )
                 all_switch_states = await eta_client.get_all_switch_states(
                     unique_switch_uris
                 )
-                for switch, (uri, on_value, _) in self.switch_queries.items():
+                for uri, on_value, _ in self.switch_queries.values():
                     result = all_switch_states.get(uri)
                     if result is None or isinstance(result, BaseException):
                         continue
-                    data[switch] = int(result) == on_value
+                    data[uri] = int(result) == on_value
 
         elapsed = time.monotonic() - start_time
         if (

--- a/custom_components/eta_webservices/entity.py
+++ b/custom_components/eta_webservices/entity.py
@@ -1,13 +1,16 @@
 """Common entity definitions for the ETA sensor integration."""
 
 from abc import abstractmethod
-from typing import Generic, TypeVar, cast
+from typing import Any, Generic, TypeVar, cast
 
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import Entity, generate_entity_id
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
 
 from .api import EtaAPI, ETAEndpoint
 from .const import (
@@ -83,7 +86,7 @@ class EtaCoordinatedSensorEntity(
 
     def __init__(  # noqa: D107
         self,
-        coordinator: ETASensorUpdateCoordinator,
+        coordinator: DataUpdateCoordinator[dict[str, Any]],
         config: dict,
         hass: HomeAssistant,
         unique_id: str,
@@ -96,7 +99,7 @@ class EtaCoordinatedSensorEntity(
         CoordinatorEntity.__init__(self, coordinator)  # pyright: ignore[reportArgumentType]
 
         self._attr_should_poll = False
-        data = self.coordinator.data.get(self.unique_id)  # pyright: ignore[reportArgumentType]
+        data = self.coordinator.data.get(self.uri)
         self.handle_data_updates(cast(_EntityT, data) if data is not None else None)
 
     @abstractmethod
@@ -106,7 +109,7 @@ class EtaCoordinatedSensorEntity(
     @callback
     def _handle_coordinator_update(self) -> None:
         """Update attributes when the coordinator updates."""
-        data = self.coordinator.data.get(self.unique_id)  # pyright: ignore[reportArgumentType]
+        data = self.coordinator.data.get(self.uri)
         self.handle_data_updates(cast(_EntityT, data) if data is not None else None)
         super()._handle_coordinator_update()
 
@@ -118,7 +121,7 @@ class EtaWritableSensorEntity(
 
     def __init__(  # noqa: D107
         self,
-        coordinator: ETAWritableUpdateCoordinator,
+        coordinator: DataUpdateCoordinator[dict[str, Any]],
         config: dict,
         hass: HomeAssistant,
         unique_id: str,

--- a/custom_components/eta_webservices/entity.py
+++ b/custom_components/eta_webservices/entity.py
@@ -18,11 +18,7 @@ from .const import (
     MAX_PARALLEL_REQUESTS,
     REQUEST_SEMAPHORE,
 )
-from .coordinator import (
-    ETAErrorUpdateCoordinator,
-    ETASensorUpdateCoordinator,
-    ETAWritableUpdateCoordinator,
-)
+from .coordinator import ETAErrorUpdateCoordinator
 from .utils import create_device_info
 
 _EntityT = TypeVar("_EntityT")
@@ -80,7 +76,9 @@ class EtaEntity(Entity):
 
 
 class EtaCoordinatedSensorEntity(
-    EtaEntity, CoordinatorEntity[ETASensorUpdateCoordinator], Generic[_EntityT]
+    EtaEntity,
+    CoordinatorEntity[DataUpdateCoordinator[dict[str, float | str | bool]]],
+    Generic[_EntityT],
 ):
     """Common coordinated sensor entity definition for normal ETA sensors."""
 
@@ -111,40 +109,6 @@ class EtaCoordinatedSensorEntity(
         """Update attributes when the coordinator updates."""
         data = self.coordinator.data.get(self.uri)
         self.handle_data_updates(cast(_EntityT, data) if data is not None else None)
-        super()._handle_coordinator_update()
-
-
-class EtaWritableSensorEntity(
-    EtaEntity, CoordinatorEntity[ETAWritableUpdateCoordinator]
-):
-    """Common sensor entity definition for all ETA sensors."""
-
-    def __init__(  # noqa: D107
-        self,
-        coordinator: DataUpdateCoordinator[dict[str, Any]],
-        config: dict,
-        hass: HomeAssistant,
-        unique_id: str,
-        endpoint_info: ETAEndpoint,
-        entity_id_format: str,
-    ) -> None:
-        EtaEntity.__init__(
-            self, config, hass, unique_id, endpoint_info, entity_id_format
-        )
-        CoordinatorEntity.__init__(self, coordinator)  # pyright: ignore[reportArgumentType]
-
-        data = self.coordinator.data.get(self.uri)
-        self.handle_data_updates(float(data) if data is not None else None)
-
-    @abstractmethod
-    def handle_data_updates(self, data: float | None) -> None:  # noqa: D102
-        raise NotImplementedError
-
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Update attributes when the coordinator updates."""
-        data = self.coordinator.data.get(self.uri)
-        self.handle_data_updates(float(data) if data is not None else None)
         super()._handle_coordinator_update()
 
 

--- a/custom_components/eta_webservices/number.py
+++ b/custom_components/eta_webservices/number.py
@@ -31,7 +31,7 @@ from .const import (
     WRITABLE_UPDATE_COORDINATOR,
 )
 from .coordinator import ETAWritableUpdateCoordinator
-from .entity import EtaWritableSensorEntity
+from .entity import EtaCoordinatedSensorEntity
 from .utils import get_native_unit
 
 _LOGGER = logging.getLogger(__name__)
@@ -71,7 +71,7 @@ async def async_setup_entry(
     )
 
 
-class EtaWritableNumberSensor(NumberEntity, EtaWritableSensorEntity):
+class EtaWritableNumberSensor(NumberEntity, EtaCoordinatedSensorEntity[float]):
     """Representation of a Number Entity."""
 
     def __init__(  # noqa: D107

--- a/custom_components/eta_webservices/sensor.py
+++ b/custom_components/eta_webservices/sensor.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from datetime import time
 import logging
+from typing import Any
 
 import voluptuous as vol
 
@@ -29,6 +30,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.entity_platform import async_get_current_platform
 from homeassistant.helpers.typing import VolDictType
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .api import ETAEndpoint, ETAError, ETAValidWritableValues
 from .const import (
@@ -48,11 +50,7 @@ from .const import (
     WRITABLE_DICT,
     WRITABLE_UPDATE_COORDINATOR,
 )
-from .coordinator import (
-    ETAErrorUpdateCoordinator,
-    ETASensorUpdateCoordinator,
-    ETAWritableUpdateCoordinator,
-)
+from .coordinator import ETAErrorUpdateCoordinator, ETASensorUpdateCoordinator
 from .entity import EtaCoordinatedSensorEntity, EtaErrorEntity, EtaWritableSensorEntity
 from .utils import get_native_unit
 
@@ -121,29 +119,12 @@ async def async_setup_entry(
             hass,
             entity,
             config[FLOAT_DICT][entity],
-            sensor_coordinator,
+            sensor_coordinator
+            if entity + "_writable" not in chosen_writable_sensors
+            else writable_coordinator,
         )
         for entity in chosen_float_sensors
-        if entity + "_writable" not in chosen_writable_sensors
     ]
-    # then add all float sensors which are also selected as writable sensors
-    # this only handles cases where a sensor is selected as both, a writable sensor and a float sensor
-    # the actual writable sensor is handled in the number entity
-    # fixme: This is a duplicate of the EtaFloatSensor class with a few differences in how the coordinator returns the data
-    # this will be refactored in a future PR
-    sensors.extend(
-        [
-            EtaFloatWritableSensor(
-                config,
-                hass,
-                entity,
-                config[FLOAT_DICT][entity],
-                writable_coordinator,
-            )
-            for entity in chosen_float_sensors
-            if entity + "_writable" in chosen_writable_sensors
-        ]  # pyright: ignore[reportArgumentType]
-    )
 
     chosen_text_sensors = config[CHOSEN_TEXT_SENSORS]
     # add the text sensors which are not also writable first
@@ -314,7 +295,7 @@ class EtaFloatSensor(SensorEntity, EtaCoordinatedSensorEntity[float]):
         hass: HomeAssistant,
         unique_id: str,
         endpoint_info: ETAEndpoint,
-        coordinator: ETASensorUpdateCoordinator,
+        coordinator: DataUpdateCoordinator[dict[str, Any]],
     ) -> None:
         _LOGGER.debug("ETA Integration - init float sensor")
 
@@ -344,45 +325,6 @@ class EtaFloatSensor(SensorEntity, EtaCoordinatedSensorEntity[float]):
         self._attr_native_value = numeric_value
 
 
-class EtaFloatWritableSensor(SensorEntity, EtaWritableSensorEntity):
-    """Representation of a Float Sensor with a coordinator."""
-
-    def __init__(  # noqa: D107
-        self,
-        config: dict,
-        hass: HomeAssistant,
-        unique_id: str,
-        endpoint_info: ETAEndpoint,
-        coordinator: ETAWritableUpdateCoordinator,
-    ) -> None:
-        _LOGGER.debug("ETA Integration - init float sensor with coordinator")
-
-        super().__init__(
-            coordinator, config, hass, unique_id, endpoint_info, ENTITY_ID_FORMAT
-        )
-
-        self._attr_device_class = _determine_device_class(endpoint_info["unit"])
-
-        self._attr_native_unit_of_measurement = get_native_unit(endpoint_info["unit"])
-
-        if self._attr_device_class == SensorDeviceClass.ENERGY:
-            self._attr_state_class = SensorStateClass.TOTAL_INCREASING
-        else:
-            self._attr_state_class = SensorStateClass.MEASUREMENT
-
-    def handle_data_updates(self, data: float | str | None) -> None:  # noqa: D102
-        numeric_value = _coerce_numeric_value(data)
-        if numeric_value is None:
-            _LOGGER.info(
-                "Writable sensor %s received non-numeric value '%s'; setting state to unavailable",
-                self.entity_id,
-                data,
-            )
-            self._attr_native_value = None
-            return
-        self._attr_native_value = numeric_value
-
-
 class EtaTextSensor(SensorEntity, EtaCoordinatedSensorEntity[str]):
     """Representation of a Text Sensor."""
 
@@ -392,7 +334,7 @@ class EtaTextSensor(SensorEntity, EtaCoordinatedSensorEntity[str]):
         hass: HomeAssistant,
         unique_id: str,
         endpoint_info: ETAEndpoint,
-        coordinator: ETASensorUpdateCoordinator,
+        coordinator: DataUpdateCoordinator[dict[str, Any]],
     ) -> None:
         _LOGGER.debug("ETA Integration - init text sensor")
 
@@ -568,7 +510,7 @@ class EtaTimeWritableSensor(SensorEntity, EtaWritableSensorEntity):
         hass: HomeAssistant,
         unique_id: str,
         endpoint_info: ETAEndpoint,
-        coordinator: ETAWritableUpdateCoordinator,
+        coordinator: DataUpdateCoordinator[dict[str, Any]],
     ) -> None:
         _LOGGER.debug("ETA Integration - init text sensor with coordinator")
 

--- a/custom_components/eta_webservices/sensor.py
+++ b/custom_components/eta_webservices/sensor.py
@@ -37,7 +37,6 @@ from .const import (
     CHOSEN_FLOAT_SENSORS,
     CHOSEN_TEXT_SENSORS,
     CHOSEN_WRITABLE_SENSORS,
-    CUSTOM_UNIT_MINUTES_SINCE_MIDNIGHT,
     CUSTOM_UNIT_TIMESLOT,
     CUSTOM_UNIT_TIMESLOT_PLUS_TEMPERATURE,
     DOMAIN,
@@ -51,7 +50,7 @@ from .const import (
     WRITABLE_UPDATE_COORDINATOR,
 )
 from .coordinator import ETAErrorUpdateCoordinator, ETASensorUpdateCoordinator
-from .entity import EtaCoordinatedSensorEntity, EtaErrorEntity, EtaWritableSensorEntity
+from .entity import EtaCoordinatedSensorEntity, EtaErrorEntity
 from .utils import get_native_unit
 
 _LOGGER = logging.getLogger(__name__)
@@ -127,7 +126,7 @@ async def async_setup_entry(
     ]
 
     chosen_text_sensors = config[CHOSEN_TEXT_SENSORS]
-    # add the text sensors which are not also writable first
+    # then add the text sensors, except for the timeslot sensors which get added in a separate loop below
     sensors.extend(
         [
             EtaTextSensor(
@@ -135,28 +134,13 @@ async def async_setup_entry(
                 hass,
                 entity,
                 config[TEXT_DICT][entity],
-                sensor_coordinator,
+                sensor_coordinator
+                if entity + "_writable" not in chosen_writable_sensors
+                else writable_coordinator,
             )
             for entity in chosen_text_sensors
-            if entity + "_writable" not in chosen_writable_sensors
-            and config[TEXT_DICT][entity]["unit"]
+            if config[TEXT_DICT][entity]["unit"]
             not in [CUSTOM_UNIT_TIMESLOT, CUSTOM_UNIT_TIMESLOT_PLUS_TEMPERATURE]
-        ]  # pyright: ignore[reportArgumentType]
-    )
-    # use a special entity if a text sensor is also added as a writable sensor
-    # this entity uses a coordinator to update the value immediately after a user sets it in the writable (time) entity
-    sensors.extend(
-        [
-            EtaTimeWritableSensor(
-                config,
-                hass,
-                entity,
-                config[TEXT_DICT][entity],
-                writable_coordinator,
-            )
-            for entity in chosen_text_sensors
-            if entity + "_writable" in chosen_writable_sensors
-            and config[TEXT_DICT][entity]["unit"] == CUSTOM_UNIT_MINUTES_SINCE_MIDNIGHT
         ]  # pyright: ignore[reportArgumentType]
     )
     # add the non-writable timeslot sensors first
@@ -499,41 +483,6 @@ class EtaTimeslotSensor(SensorEntity, EtaCoordinatedSensorEntity[str]):
             )
         else:
             self._attr_native_value = f"{start_time} - {end_time}"
-
-
-class EtaTimeWritableSensor(SensorEntity, EtaWritableSensorEntity):
-    """Representation of a Text Sensor (displaying a time) with a coordinator."""
-
-    def __init__(  # noqa: D107
-        self,
-        config: dict,
-        hass: HomeAssistant,
-        unique_id: str,
-        endpoint_info: ETAEndpoint,
-        coordinator: DataUpdateCoordinator[dict[str, Any]],
-    ) -> None:
-        _LOGGER.debug("ETA Integration - init text sensor with coordinator")
-
-        super().__init__(
-            coordinator, config, hass, unique_id, endpoint_info, ENTITY_ID_FORMAT
-        )
-
-    def handle_data_updates(self, data: float | None) -> None:  # noqa: D102
-        # the coordinator returns the minutes since midnight, not the textual representation
-        # so we have to calculate the textual representation here
-        if data is None:
-            _LOGGER.info(
-                "Sensor %s received None value; setting state to unavailable",
-                self.entity_id,
-            )
-            self._attr_native_value = None
-            return
-
-        total_minutes = int(data)
-        hours = total_minutes // 60
-        minutes = total_minutes % 60
-
-        self._attr_native_value = f"{hours:02d}:{minutes:02d}"
 
 
 class EtaNbrErrorsSensor(SensorEntity, EtaErrorEntity):

--- a/custom_components/eta_webservices/switch.py
+++ b/custom_components/eta_webservices/switch.py
@@ -58,13 +58,13 @@ class EtaSwitch(EtaEntity, SwitchEntity, CoordinatorEntity[ETASensorUpdateCoordi
 
         self.on_value = endpoint_info["valid_values"].get("on_value", 1803)  # pyright: ignore[reportOptionalMemberAccess]
         self.off_value = endpoint_info["valid_values"].get("off_value", 1802)  # pyright: ignore[reportOptionalMemberAccess]
-        data = self.coordinator.data.get(self.unique_id)  # pyright: ignore[reportArgumentType]
+        data = self.coordinator.data.get(self.uri)
         self._attr_is_on = bool(data) if data is not None else None
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Update attributes when the coordinator updates."""
-        data = self.coordinator.data.get(self.unique_id)  # pyright: ignore[reportArgumentType]
+        data = self.coordinator.data.get(self.uri)
         self._attr_is_on = bool(data) if data is not None else None
         super()._handle_coordinator_update()
 

--- a/custom_components/eta_webservices/time.py
+++ b/custom_components/eta_webservices/time.py
@@ -20,7 +20,7 @@ from .const import (
     WRITABLE_UPDATE_COORDINATOR,
 )
 from .coordinator import ETAWritableUpdateCoordinator
-from .entity import EtaWritableSensorEntity
+from .entity import EtaCoordinatedSensorEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -44,7 +44,7 @@ async def async_setup_entry(
     async_add_entities(time_sensors, update_before_add=True)
 
 
-class EtaTime(TimeEntity, EtaWritableSensorEntity):
+class EtaTime(TimeEntity, EtaCoordinatedSensorEntity[str]):
     """Representation of a Time Sensor."""
 
     def __init__(  # noqa: D107
@@ -66,7 +66,7 @@ class EtaTime(TimeEntity, EtaWritableSensorEntity):
         # set an initial value to avoid errors. This will be overwritten by the coordinator immediately after initialization.
         self._attr_native_value = time(hour=19)
 
-    def handle_data_updates(self, data: float | None) -> None:
+    def handle_data_updates(self, data: str | None) -> None:
         """Calculate the actual time from the minutes since midnight and set the entity's value."""
         if data is None:
             _LOGGER.info(
@@ -75,12 +75,8 @@ class EtaTime(TimeEntity, EtaWritableSensorEntity):
             )
             self._attr_native_value = None
             return
-
-        total_minutes = int(data)
-        hours = total_minutes // 60
-        minutes = total_minutes % 60
-
-        self._attr_native_value = time(hour=hours, minute=minutes)
+        parsed_time = time.fromisoformat(data)
+        self._attr_native_value = parsed_time
 
     async def async_set_value(self, value: time):
         """Calculate the minutes since midnight and write the value to the endpoint."""

--- a/tests/custom_components/eta_webservices/test_coordinator_assignment.py
+++ b/tests/custom_components/eta_webservices/test_coordinator_assignment.py
@@ -31,6 +31,7 @@ from custom_components.eta_webservices.const import (
     CHOSEN_SWITCHES,
     CHOSEN_TEXT_SENSORS,
     CHOSEN_WRITABLE_SENSORS,
+    CUSTOM_UNIT_MINUTES_SINCE_MIDNIGHT,
     DOMAIN,
     ERROR_UPDATE_COORDINATOR,
     FLOAT_DICT,
@@ -56,9 +57,11 @@ def _make_api_mock(float_dict, text_dict, writable_dict, switch_dict):
     for info in text_dict.values():
         uri_to_value[info["url"]] = str(info["value"])
     for info in writable_dict.values():
-        # Use 0 as a safe numeric default — some fixture values are strings like
-        # "xxx" or "21:00" that cannot be passed through float().
-        uri_to_value[info["url"]] = 0
+        # Time sensors expect an ISO time string; numeric sensors can use 0.
+        if info["unit"] == CUSTOM_UNIT_MINUTES_SINCE_MIDNIGHT:
+            uri_to_value[info["url"]] = "00:00"
+        else:
+            uri_to_value[info["url"]] = 0
 
     uri_to_switch = {
         info["url"]: int(info["valid_values"]["off_value"])
@@ -68,7 +71,9 @@ def _make_api_mock(float_dict, text_dict, writable_dict, switch_dict):
 
     mock_api = AsyncMock()
     mock_api.get_all_data = AsyncMock(
-        side_effect=lambda q: {uri: uri_to_value[uri] for uri in q if uri in uri_to_value}
+        side_effect=lambda q: {
+            uri: uri_to_value[uri] for uri in q if uri in uri_to_value
+        }
     )
     mock_api.get_all_switch_states = AsyncMock(
         side_effect=lambda uris: {uri: uri_to_switch.get(uri, 1802) for uri in uris}
@@ -77,7 +82,9 @@ def _make_api_mock(float_dict, text_dict, writable_dict, switch_dict):
     return mock_api
 
 
-def _assert_coordinator_assignments(all_entities, sensor_coordinator, writable_coordinator, error_coordinator):
+def _assert_coordinator_assignments(
+    all_entities, sensor_coordinator, writable_coordinator, error_coordinator
+):
     """Assert that every entity is fed by exactly one coordinator that has data for it."""
     for entity in all_entities:
         if isinstance(entity, EtaErrorEntity):
@@ -133,7 +140,10 @@ async def _run_test(
 
     with (
         patch("custom_components.eta_webservices.coordinator.async_get_clientsession"),
-        patch("custom_components.eta_webservices.coordinator.EtaAPI", return_value=mock_api),
+        patch(
+            "custom_components.eta_webservices.coordinator.EtaAPI",
+            return_value=mock_api,
+        ),
         patch("custom_components.eta_webservices.entity.async_get_clientsession"),
         patch("custom_components.eta_webservices.number.async_get_current_platform"),
         patch("custom_components.eta_webservices.sensor.async_get_current_platform"),
@@ -183,28 +193,27 @@ async def test_coordinator_assignment_all_sensors(hass: HomeAssistant, load_fixt
     writable_dict = fixture["writable_dict"]
     switch_dict = fixture["switches_dict"]
 
-    all_entities, sensor_coordinator, writable_coordinator, error_coordinator = (
-        await _run_test(
-            hass,
-            float_dict,
-            text_dict,
-            writable_dict,
-            switch_dict,
-            chosen_float_sensors=list(float_dict),
-            chosen_text_sensors=list(text_dict),
-            chosen_writable_sensors=list(writable_dict),
-            chosen_switches=list(switch_dict),
-            entry_id="test_all_sensors",
-        )
+    (
+        all_entities,
+        sensor_coordinator,
+        writable_coordinator,
+        error_coordinator,
+    ) = await _run_test(
+        hass,
+        float_dict,
+        text_dict,
+        writable_dict,
+        switch_dict,
+        chosen_float_sensors=list(float_dict),
+        chosen_text_sensors=list(text_dict),
+        chosen_writable_sensors=list(writable_dict),
+        chosen_switches=list(switch_dict),
+        entry_id="test_all_sensors",
     )
 
     # Sanity-check entity count (mirrors test_all_writable_and_non_writable_sensors_handled)
     assert len(all_entities) == (
-        len(float_dict)
-        + len(text_dict)
-        + len(writable_dict)
-        + len(switch_dict)
-        + 2
+        len(float_dict) + len(text_dict) + len(writable_dict) + len(switch_dict) + 2
     )
 
     _assert_coordinator_assignments(
@@ -213,10 +222,12 @@ async def test_coordinator_assignment_all_sensors(hass: HomeAssistant, load_fixt
 
 
 @pytest.mark.asyncio
-async def test_coordinator_assignment_no_writable_sensors(hass: HomeAssistant, load_fixture):
+async def test_coordinator_assignment_no_writable_sensors(
+    hass: HomeAssistant, load_fixture
+):
     """chosen_writable_sensors is empty: all regular entities use sensor_coordinator only.
 
-    No EtaWritableNumberSensor, EtaTime, or EtaTimeWritableSensor should be created.
+    No EtaWritableNumberSensor or EtaTime should be created.
     Every non-error entity must be in sensor_coordinator.data.
     """
     fixture = load_fixture("api_assignment_reference_values_v12.json")
@@ -225,19 +236,22 @@ async def test_coordinator_assignment_no_writable_sensors(hass: HomeAssistant, l
     writable_dict = fixture["writable_dict"]
     switch_dict = fixture["switches_dict"]
 
-    all_entities, sensor_coordinator, writable_coordinator, error_coordinator = (
-        await _run_test(
-            hass,
-            float_dict,
-            text_dict,
-            writable_dict,
-            switch_dict,
-            chosen_float_sensors=list(float_dict),
-            chosen_text_sensors=list(text_dict),
-            chosen_writable_sensors=[],
-            chosen_switches=list(switch_dict),
-            entry_id="test_no_writable",
-        )
+    (
+        all_entities,
+        sensor_coordinator,
+        writable_coordinator,
+        error_coordinator,
+    ) = await _run_test(
+        hass,
+        float_dict,
+        text_dict,
+        writable_dict,
+        switch_dict,
+        chosen_float_sensors=list(float_dict),
+        chosen_text_sensors=list(text_dict),
+        chosen_writable_sensors=[],
+        chosen_switches=list(switch_dict),
+        entry_id="test_no_writable",
     )
 
     assert len(all_entities) == len(float_dict) + len(text_dict) + len(switch_dict) + 2
@@ -248,7 +262,9 @@ async def test_coordinator_assignment_no_writable_sensors(hass: HomeAssistant, l
 
 
 @pytest.mark.asyncio
-async def test_coordinator_assignment_only_writable_sensors(hass: HomeAssistant, load_fixture):
+async def test_coordinator_assignment_only_writable_sensors(
+    hass: HomeAssistant, load_fixture
+):
     """Only chosen_writable_sensors is populated; all other chosen lists are empty.
 
     Only EtaWritableNumberSensor, EtaTime, EtaTimeslotSensor (writable variant), and
@@ -260,19 +276,22 @@ async def test_coordinator_assignment_only_writable_sensors(hass: HomeAssistant,
     writable_dict = fixture["writable_dict"]
     switch_dict = fixture["switches_dict"]
 
-    all_entities, sensor_coordinator, writable_coordinator, error_coordinator = (
-        await _run_test(
-            hass,
-            float_dict,
-            text_dict,
-            writable_dict,
-            switch_dict,
-            chosen_float_sensors=[],
-            chosen_text_sensors=[],
-            chosen_writable_sensors=list(writable_dict),
-            chosen_switches=[],
-            entry_id="test_only_writable",
-        )
+    (
+        all_entities,
+        sensor_coordinator,
+        writable_coordinator,
+        error_coordinator,
+    ) = await _run_test(
+        hass,
+        float_dict,
+        text_dict,
+        writable_dict,
+        switch_dict,
+        chosen_float_sensors=[],
+        chosen_text_sensors=[],
+        chosen_writable_sensors=list(writable_dict),
+        chosen_switches=[],
+        entry_id="test_only_writable",
     )
 
     assert len(all_entities) == len(writable_dict) + 2

--- a/tests/custom_components/eta_webservices/test_coordinator_assignment.py
+++ b/tests/custom_components/eta_webservices/test_coordinator_assignment.py
@@ -87,8 +87,8 @@ def _assert_coordinator_assignments(all_entities, sensor_coordinator, writable_c
             continue
 
         if entity.coordinator is sensor_coordinator:
-            assert entity.unique_id in sensor_coordinator.data, (
-                f"{type(entity).__name__} {entity.unique_id!r} missing from sensor_coordinator.data"
+            assert entity.uri in sensor_coordinator.data, (
+                f"{type(entity).__name__} {entity.unique_id!r} uri={entity.uri!r} missing from sensor_coordinator.data"
             )
         elif entity.coordinator is writable_coordinator:
             assert entity.uri in writable_coordinator.data, (
@@ -172,8 +172,9 @@ async def _run_test(
 async def test_coordinator_assignment_all_sensors(hass: HomeAssistant, load_fixture):
     """All four chosen lists fully populated: every entity uses the correct coordinator.
 
-    The sensor_coordinator serves float, text, timeslot, and switch entities.
-    The writable_coordinator serves writable number, time, and float-writable entities.
+    The sensor_coordinator serves float, text, timeslot, and switch entities (unless the
+    float sensor is also writable, in which case it uses the writable_coordinator).
+    The writable_coordinator serves writable number, time, and writable float entities.
     Error entities always use the error_coordinator.
     """
     fixture = load_fixture("api_assignment_reference_values_v12.json")
@@ -215,8 +216,8 @@ async def test_coordinator_assignment_all_sensors(hass: HomeAssistant, load_fixt
 async def test_coordinator_assignment_no_writable_sensors(hass: HomeAssistant, load_fixture):
     """chosen_writable_sensors is empty: all regular entities use sensor_coordinator only.
 
-    No EtaWritableNumberSensor, EtaTime, EtaFloatWritableSensor, or EtaTimeWritableSensor
-    should be created. Every non-error entity must be in sensor_coordinator.data.
+    No EtaWritableNumberSensor, EtaTime, or EtaTimeWritableSensor should be created.
+    Every non-error entity must be in sensor_coordinator.data.
     """
     fixture = load_fixture("api_assignment_reference_values_v12.json")
     float_dict = fixture["float_dict"]

--- a/tests/custom_components/eta_webservices/test_handle_data_updates.py
+++ b/tests/custom_components/eta_webservices/test_handle_data_updates.py
@@ -23,7 +23,6 @@ from custom_components.eta_webservices.number import EtaWritableNumberSensor
 from custom_components.eta_webservices.switch import EtaSwitch
 from custom_components.eta_webservices.sensor import (
     EtaFloatSensor,
-    EtaFloatWritableSensor,
     EtaTextSensor,
     EtaTimeslotSensor,
     EtaTimeWritableSensor,
@@ -95,9 +94,9 @@ def _make_writable_endpoint(url=_URL, unit="°C"):
 
 
 def _make_sensor_coordinator(value=42.0):
-    """Coordinator keyed by unique_id (used by EtaCoordinatedSensorEntity subclasses)."""
+    """Coordinator keyed by URI (used by EtaCoordinatedSensorEntity subclasses)."""
     c = MagicMock()
-    c.data = {_UNIQUE_ID: value}
+    c.data = {_URL: value}
     return c
 
 
@@ -128,7 +127,7 @@ def _assert_clears_native_value(entity, coordinator, dummy_data):
 
 
 def test_eta_float_sensor_clears_value_when_key_missing(hass: HomeAssistant):
-    """EtaFloatSensor._attr_native_value is None when its unique_id is absent from data."""
+    """EtaFloatSensor._attr_native_value is None when its URI is absent from data."""
     coordinator = _make_sensor_coordinator(42.0)
     with patch("custom_components.eta_webservices.entity.async_get_clientsession"):
         entity = EtaFloatSensor(
@@ -136,24 +135,6 @@ def test_eta_float_sensor_clears_value_when_key_missing(hass: HomeAssistant):
         )
 
     assert entity._attr_native_value is not None  # sanity: starts with a real value
-
-    _assert_clears_native_value(entity, coordinator, {_OTHER_UNIQUE_ID: 0.0})
-
-
-# ---------------------------------------------------------------------------
-# sensor.py — EtaFloatWritableSensor
-# ---------------------------------------------------------------------------
-
-
-def test_eta_float_writable_sensor_clears_value_when_key_missing(hass: HomeAssistant):
-    """EtaFloatWritableSensor._attr_native_value is None when its URI is absent from data."""
-    coordinator = _make_writable_coordinator(42.0)
-    with patch("custom_components.eta_webservices.entity.async_get_clientsession"):
-        entity = EtaFloatWritableSensor(
-            _make_config(), hass, _UNIQUE_ID, _make_float_endpoint(), coordinator
-        )
-
-    assert entity._attr_native_value is not None
 
     _assert_clears_native_value(entity, coordinator, {_OTHER_URL: 0.0})
 
@@ -164,7 +145,7 @@ def test_eta_float_writable_sensor_clears_value_when_key_missing(hass: HomeAssis
 
 
 def test_eta_text_sensor_clears_value_when_key_missing(hass: HomeAssistant):
-    """EtaTextSensor._attr_native_value is None when its unique_id is absent from data."""
+    """EtaTextSensor._attr_native_value is None when its URI is absent from data."""
     coordinator = _make_sensor_coordinator("Ein")
     with patch("custom_components.eta_webservices.entity.async_get_clientsession"):
         entity = EtaTextSensor(
@@ -173,7 +154,7 @@ def test_eta_text_sensor_clears_value_when_key_missing(hass: HomeAssistant):
 
     assert entity._attr_native_value is not None
 
-    _assert_clears_native_value(entity, coordinator, {_OTHER_UNIQUE_ID: "Aus"})
+    _assert_clears_native_value(entity, coordinator, {_OTHER_URL: "Aus"})
 
 
 # ---------------------------------------------------------------------------
@@ -182,7 +163,7 @@ def test_eta_text_sensor_clears_value_when_key_missing(hass: HomeAssistant):
 
 
 def test_eta_timeslot_sensor_clears_value_when_key_missing(hass: HomeAssistant):
-    """EtaTimeslotSensor._attr_native_value is None when its unique_id is absent from data."""
+    """EtaTimeslotSensor._attr_native_value is None when its URI is absent from data."""
     coordinator = _make_sensor_coordinator("15:00 - 16:00")
     with patch("custom_components.eta_webservices.entity.async_get_clientsession"):
         entity = EtaTimeslotSensor(
@@ -196,9 +177,7 @@ def test_eta_timeslot_sensor_clears_value_when_key_missing(hass: HomeAssistant):
 
     assert entity._attr_native_value is not None
 
-    _assert_clears_native_value(
-        entity, coordinator, {_OTHER_UNIQUE_ID: "09:00 - 10:00"}
-    )
+    _assert_clears_native_value(entity, coordinator, {_OTHER_URL: "09:00 - 10:00"})
 
 
 # ---------------------------------------------------------------------------
@@ -286,7 +265,7 @@ def test_eta_switch_clears_is_on_when_key_missing(hass: HomeAssistant):
 
     assert entity._attr_is_on is not None  # sanity: True after construction
 
-    coordinator.data = {_OTHER_UNIQUE_ID: True}
+    coordinator.data = {_OTHER_URL: True}
     with patch.object(entity, "async_write_ha_state"):
         entity._handle_coordinator_update()
     assert entity._attr_is_on is None

--- a/tests/custom_components/eta_webservices/test_handle_data_updates.py
+++ b/tests/custom_components/eta_webservices/test_handle_data_updates.py
@@ -25,7 +25,6 @@ from custom_components.eta_webservices.sensor import (
     EtaFloatSensor,
     EtaTextSensor,
     EtaTimeslotSensor,
-    EtaTimeWritableSensor,
 )
 from custom_components.eta_webservices.time import EtaTime
 
@@ -35,7 +34,6 @@ from custom_components.eta_webservices.time import EtaTime
 
 _UNIQUE_ID = "test_entity"
 _URL = "/test/url/123"
-_OTHER_UNIQUE_ID = "other_entity"
 _OTHER_URL = "/other/url/456"
 
 
@@ -181,28 +179,6 @@ def test_eta_timeslot_sensor_clears_value_when_key_missing(hass: HomeAssistant):
 
 
 # ---------------------------------------------------------------------------
-# sensor.py — EtaTimeWritableSensor
-# ---------------------------------------------------------------------------
-
-
-def test_eta_time_writable_sensor_clears_value_when_key_missing(hass: HomeAssistant):
-    """EtaTimeWritableSensor._attr_native_value is None when its URI is absent from data."""
-    coordinator = _make_writable_coordinator(42.0)
-    with patch("custom_components.eta_webservices.entity.async_get_clientsession"):
-        entity = EtaTimeWritableSensor(
-            _make_config(),
-            hass,
-            _UNIQUE_ID,
-            _make_float_endpoint(unit=CUSTOM_UNIT_MINUTES_SINCE_MIDNIGHT),
-            coordinator,
-        )
-
-    assert entity._attr_native_value is not None
-
-    _assert_clears_native_value(entity, coordinator, {_OTHER_URL: 42.0})
-
-
-# ---------------------------------------------------------------------------
 # number.py — EtaWritableNumberSensor
 # ---------------------------------------------------------------------------
 
@@ -231,7 +207,7 @@ def test_eta_time_clears_value_when_key_missing(hass: HomeAssistant):
     EtaTime always sets _attr_native_value = time(hour=19) after its parent __init__,
     so the entity starts with a non-None value regardless of coordinator data.
     """
-    coordinator = _make_writable_coordinator(42.0)
+    coordinator = _make_writable_coordinator("19:00")
     with patch("custom_components.eta_webservices.entity.async_get_clientsession"):
         entity = EtaTime(
             _make_config(),
@@ -243,7 +219,7 @@ def test_eta_time_clears_value_when_key_missing(hass: HomeAssistant):
 
     assert entity._attr_native_value is not None  # time(hour=19) after construction
 
-    _assert_clears_native_value(entity, coordinator, {_OTHER_URL: 0.0})
+    _assert_clears_native_value(entity, coordinator, {_OTHER_URL: "00:00"})
 
 
 # ---------------------------------------------------------------------------

--- a/tests/custom_components/eta_webservices/test_platforms.py
+++ b/tests/custom_components/eta_webservices/test_platforms.py
@@ -26,6 +26,7 @@ from custom_components.eta_webservices.const import (
     CHOSEN_SWITCHES,
     CHOSEN_TEXT_SENSORS,
     CHOSEN_WRITABLE_SENSORS,
+    CUSTOM_UNIT_MINUTES_SINCE_MIDNIGHT,
     DOMAIN,
     ERROR_UPDATE_COORDINATOR,
     FLOAT_DICT,
@@ -76,12 +77,16 @@ async def test_all_writable_sensors_handled(hass: HomeAssistant, load_fixture):
     chosen_writable_sensors = list(writable_dict.keys())
 
     # Mock coordinators — CoordinatorEntity.__init__ only sets self.coordinator,
-    # so MagicMock is safe. .data must be a real dict so that
-    # EtaWritableSensorEntity.__init__ can do float(coordinator.data[self.uri]).
-    # Use 0 as a safe numeric default: some fixture entries have string values
-    # (e.g. 'xxx', '21:00') that can't be float()-ed.
+    # so MagicMock is safe. .data must be a real dict so that entity constructors
+    # can call coordinator.data.get(self.uri). Time sensors expect an ISO time string;
+    # all other writable sensors can safely use 0.
     writable_coordinator = MagicMock()
-    writable_coordinator.data = {info["url"]: 0 for info in writable_dict.values()}
+    writable_coordinator.data = {
+        info["url"]: "00:00"
+        if info["unit"] == CUSTOM_UNIT_MINUTES_SINCE_MIDNIGHT
+        else 0
+        for info in writable_dict.values()
+    }
     sensor_coordinator = MagicMock()
     sensor_coordinator.data = {}
     error_coordinator = MagicMock()
@@ -212,10 +217,10 @@ async def test_all_writable_and_non_writable_sensors_handled(
 
     With every sensor chosen simultaneously the platforms partition the work as:
     - sensor.py: every float sensor → EtaFloatSensor or EtaFloatWritableSensor (1 each);
-                 non-timeslot text sensors without a writable counterpart → EtaTextSensor;
-                 minutes_since_midnight text sensors with a writable counterpart → EtaTimeWritableSensor;
-                 all timeslot text sensors → EtaTimeslotSensor (read-only);
-                 writable timeslot sensors → EtaTimeslotSensor (writable, separate entity);
+                 non-timeslot text sensors → EtaTextSensor (uses writable_coordinator if also writable);
+                 timeslot text sensors WITHOUT a writable counterpart → EtaTimeslotSensor;
+                 writable timeslot sensors → EtaTimeslotSensor (1 each, subsumes the
+                   text-side timeslot sensor when both are selected);
                  2 always-present error sensors.
     - number.py: writable sensors with regular / unitless units → EtaWritableNumberSensor.
     - time.py:   writable sensors with minutes_since_midnight   → EtaTime.
@@ -235,11 +240,16 @@ async def test_all_writable_and_non_writable_sensors_handled(
     chosen_text_sensors = list(text_dict.keys())
     chosen_writable_sensors = list(writable_dict.keys())
 
-    # EtaFloatWritableSensor and EtaTimeWritableSensor look up their URL in
-    # coordinator.data. The float/text sensor URLs always match the writable
-    # counterpart URLs (same physical endpoint), so writable_dict URLs suffice.
+    # Entity constructors look up their URL in coordinator.data. The float/text sensor
+    # URLs always match the writable counterpart URLs (same physical endpoint), so
+    # writable_dict URLs suffice. Time sensors expect an ISO time string; others use 0.
     writable_coordinator = MagicMock()
-    writable_coordinator.data = {info["url"]: 0 for info in writable_dict.values()}
+    writable_coordinator.data = {
+        info["url"]: "00:00"
+        if info["unit"] == CUSTOM_UNIT_MINUTES_SINCE_MIDNIGHT
+        else 0
+        for info in writable_dict.values()
+    }
     sensor_coordinator = MagicMock()
     sensor_coordinator.data = {}
     error_coordinator = MagicMock()
@@ -282,11 +292,7 @@ async def test_all_writable_and_non_writable_sensors_handled(
         await switch_async_setup_entry(hass, config_entry, add_entities)
 
     assert len(all_entities) == (
-        len(float_dict)
-        + len(text_dict)
-        + len(writable_dict)
-        + len(switch_dict)
-        + 2
+        len(float_dict) + len(text_dict) + len(writable_dict) + len(switch_dict) + 2
     )
 
 


### PR DESCRIPTION
- Refactor coordinator handling
   - Merged duplicate sensor classes (`EtaTimeWritableSensor` and `EtaTextSensor`, `EtaFloatWritableSensor` and `EtaFloatSensor`)
   - Merged duplicate coordinator entities (`EtaWritableSensorEntity` and `EtaCoordinatedSensorEntity`)
   - Coordinators now always return the text value for `CUSTOM_UNIT_MINUTES_SINCE_MIDNIGHT`, instead of the numeric value


Related to #68 