### PR TITLE
docs(readme): add reference to eta-flow integration to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ This integration can be configured directly in Home Assistant via HACS:
 
 -   Your ETA heating unit needs a static IP address! Either configure the IP adress directly on the ETA terminal, or set the DHCP server on your router to give the ETA unit a static lease.
 
+## Related Integrations
+
+You can check out this HACS integration [eta-flow](https://github.com/orazefabian/eta-flow) which provides an animated heat-flow card for visualizing an ETA heating system.
+
 ## Updating the List of Sensors
 
 If the sensors on the ETA unit are changed, the integration can be updated to reflect that. This is useful for example if new sensors are added, which should be shown in HA.


### PR DESCRIPTION
## Summary

Hey, I just wanted to cross-link an integration I built for visualizing the eta-heating flow using the sensors provided by this integration. See repo: https://github.com/orazefabian/eta-flow

My integration is still rather in its infancy but it would be cool if it would attract some users of the `homeassistant_eta_integration` and perhaps get some feedback.

Edit: Added a `Related Integrations` right after the `General Notes` section as suggested in the review comment.